### PR TITLE
[Chore] Gitignore Python coverage data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,11 @@ lib-cov
 coverage
 *.lcov
 
+# Python coverage data. The bare `coverage` pattern above matches the
+# directory only, not coverage.py's `.coverage` data file.
+.coverage
+.coverage.*
+
 # nyc test coverage
 .nyc_output
 


### PR DESCRIPTION
The existing `coverage` pattern matches the istanbul/JS coverage *directory*, not coverage.py's `.coverage` data file. Test runs therefore left a dirty working tree, which blocked branch switches and automation today.

Adds `.coverage` and `.coverage.*`.

**Note:** `.coverage` is still *tracked* on `release/v0.2.X`. This change only stops it being re-added on `main` — untracking it there needs `git rm --cached .coverage` on that branch, which currently has uncommitted work and was deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)