### PR TITLE
[Fix] CI: build management image from services/ and include shared/

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -113,6 +113,12 @@ jobs:
           - service: webui
             context: ./services/webui
             dockerfile: ./services/webui/Dockerfile
+          # management moved to services/ in the Phase-1 consolidation; the
+          # default ./{service}/Dockerfile no longer exists. Context stays the
+          # repo root so the image can COPY the shared/ package it imports.
+          - service: management
+            context: .
+            dockerfile: ./services/management/Dockerfile
 
     steps:
     - name: Checkout code

--- a/services/management/Dockerfile
+++ b/services/management/Dockerfile
@@ -17,7 +17,7 @@ RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Install Python dependencies
-COPY requirements.txt /tmp/requirements.txt
+COPY services/management/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r /tmp/requirements.txt
 
@@ -40,9 +40,15 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Set working directory
 WORKDIR /app
 
-# Copy application code
-COPY app/ /app/app/
-COPY asgi.py /app/
+# Copy application code. Build context is the REPO ROOT (as for the proxy
+# image) because this service imports the top-level `shared` package —
+# shared.auth.penguin_auth and shared.security.credential_encryption are used
+# by app/api/v1/auth.py, providers.py and services/provider_sync.py. Building
+# from services/management/ as context produced an image that ImportErrors on
+# startup because shared/ was never copied in.
+COPY shared/ /app/shared/
+COPY services/management/app/ /app/app/
+COPY services/management/asgi.py /app/
 
 # Create necessary directories
 RUN mkdir -p /app/config/marchproxy /app/logs /app/databases && \

--- a/tests/smoke/test_management_build.sh
+++ b/tests/smoke/test_management_build.sh
@@ -97,7 +97,7 @@ echo "Test 3: Docker build check..."
 if command -v docker &> /dev/null; then
     echo "Building Docker image..."
     cd "$PROJECT_ROOT"
-    if docker build -t waddleai-mgmt-test:smoke -f services/management/Dockerfile services/management/ > /tmp/waddleai-build.log 2>&1; then
+    if docker build -t waddleai-mgmt-test:smoke -f services/management/Dockerfile . > /tmp/waddleai-build.log 2>&1; then
         pass "Docker build successful"
         # Clean up test image
         docker rmi waddleai-mgmt-test:smoke > /dev/null 2>&1 || true


### PR DESCRIPTION
CI's build-platform job failed on both architectures with: ERROR: failed to build: resolve : lstat management: no such file or directory

The workflow still built the management image from the pre-consolidation ./management/ path. PR #50 moved the service to services/management/; the stale path only surfaced once the dead management/ tree was removed.

**Fixing the path exposed a worse problem.** The Dockerfile copied only app/ and asgi.py — never the top-level shared/ package, which app/api/v1/auth.py, app/api/v1/providers.py and app/services/provider_sync.py all import. The published management image would ImportError on startup. A green build proved nothing, because the failure is at runtime.

Changes:
- workflow: management builds with context '.' and file ./services/management/Dockerfile, matching how proxy already builds
- Dockerfile: COPY shared/ plus repo-root-relative paths for requirements, app/ and asgi.py
- smoke test: build context updated to match

Verified by building the image locally and running it — /app/shared is present and 'import shared.auth.penguin_auth' succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)