### PR TITLE
chore(git): ignore .worktrees/ and .superpowers/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 .PLAN
 .TODO
 
+# Git worktrees — one per feature/fix/chore branch, each a full checkout
+.worktrees/
+
+# Subagent-driven-development progress ledger (scratch)
+.superpowers/
+
 # Python
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Prerequisite for the worktree-per-branch workflow.

`.worktrees/` is the fixed location for feature/fix/chore worktrees, but it was never gitignored — each worktree is a full checkout, so it would show as untracked noise on every `git status` and `git add -A` would try to commit one.

Also ignores `.superpowers/`, which holds the subagent-driven-development progress ledger (scratch state by design, untracked today but unignored).

Verified in a scratch repo that both patterns match real nested paths — a trailing-slash pattern only matches when the path exists as a directory, so `git check-ignore` inside a fresh worktree reports a false negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)