### PR TITLE
fix(ci): scan the real management path and gate on HIGH bandit findings

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,17 +5,19 @@ on:
     branches: [ main, 'v*' ]
     paths:
       - 'proxy/**'
-      - 'management/**'
       - 'services/**'
       - 'shared/**'
       - '.version'
       - '.github/workflows/docker-build.yml'
     tags: [ 'v*' ]
   pull_request:
-    branches: [ main ]
+    # release/** matters as much as main: feature/fix/chore branches merge into
+    # the release branch first, and that merge is auto-approved when "fully
+    # green". Without this, release-targeted PRs ran no tests and no builds at
+    # all, so the green gate passed on PRs that had never been built.
+    branches: [ main, 'release/**' ]
     paths:
       - 'proxy/**'
-      - 'management/**'
       - 'services/**'
       - 'shared/**'
       - '.version'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -89,7 +89,11 @@ jobs:
 
     - name: Run security check (bandit)
       run: |
-        bandit -r proxy management shared -ll -f json -o bandit-results.json || true
+        # Two passes on purpose: the first records every medium+ finding to the
+        # JSON report without gating the build; the second gates on HIGH only, so
+        # a high-severity finding fails CI instead of being swallowed.
+        bandit -r proxy services/management shared -ll -f json -o bandit-results.json || true
+        bandit -r proxy services/management shared -lll
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6

--- a/shared/security/prompt_security.py
+++ b/shared/security/prompt_security.py
@@ -346,7 +346,9 @@ class PromptSecurityScanner:
             prompt_sample = original_prompt[:1000] if original_prompt else ""
 
             # Generate request hash
-            request_hash = hashlib.md5((original_prompt + str(datetime.utcnow().timestamp())).encode()).hexdigest()
+            request_hash = hashlib.md5(
+                (original_prompt + str(datetime.utcnow().timestamp())).encode(), usedforsecurity=False
+            ).hexdigest()
 
             # Log to database
             self.db.security_logs.insert(

--- a/shared/utils/rag_integration.py
+++ b/shared/utils/rag_integration.py
@@ -388,7 +388,7 @@ class QdrantRAGStore(RAGStore):
 
                 # Create point
                 point = PointStruct(
-                    id=hashlib.md5(doc.id.encode()).hexdigest()[:16],  # Qdrant uses int/UUID
+                    id=hashlib.md5(doc.id.encode(), usedforsecurity=False).hexdigest()[:16],  # Qdrant uses int/UUID
                     vector=doc.embedding,
                     payload={
                         "doc_id": doc.id,


### PR DESCRIPTION
## Problem

The bandit step in `docker-build.yml` scanned `proxy management shared`, but `management/` was deleted during the consolidation — the service is now `services/management/`. Bandit recorded a path error and continued; `|| true` ensured nobody ever saw it.

**Measured:** the old invocation scans **63 files**; corrected, it scans **113**. The control plane has been unscanned since consolidation.

`|| true` also meant no finding at any severity could fail the build.

## Changes

| File | Change |
|---|---|
| `.github/workflows/docker-build.yml` | Path → `services/management`; second HIGH-only bandit pass that actually gates CI (medium+ JSON report stays non-blocking) |
| `shared/security/prompt_security.py` | `usedforsecurity=False` on MD5 used for a `security_logs` record identifier |
| `shared/utils/rag_integration.py` | `usedforsecurity=False` on MD5 used for a Qdrant point ID |

Both MD5 uses were verified non-cryptographic — marked accurately rather than suppressed with `# nosec`, and the algorithm is unchanged so derived IDs stay stable.

## Verification (run on this branch)

- `bandit -r proxy services/management shared -lll` → **0 issues, exit 0** (the new gate passes on the current tree)
- `bandit ... -ll` → **113 files scanned, `errors: []`, 0 HIGH, 15 MEDIUM** (was 63 files with a path error)
- `yaml.safe_load` on the workflow → ok

The 15 remaining MEDIUM findings (B104 bind-all-interfaces, B608 SQL-string, B108 temp-file) are reported but non-blocking, unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)