### PR TITLE
fix(webui): clear react-router advisory and repair pre-existing lint/test failures

### DIFF
--- a/services/webui/.eslintrc.cjs
+++ b/services/webui/.eslintrc.cjs
@@ -18,4 +18,13 @@ module.exports = {
     ],
     'react/prop-types': 'off',
   },
+  overrides: [
+    {
+      // Vitest runs test files under Node, where `global` is the runtime
+      // object tests stub (e.g. `global.fetch = vi.fn()`) — distinct from
+      // the jsdom `window`/`browser` globals declared above.
+      files: ['src/test/**/*.{js,jsx}'],
+      env: { node: true },
+    },
+  ],
 }

--- a/services/webui/package-lock.json
+++ b/services/webui/package-lock.json
@@ -11,7 +11,7 @@
         "axios": "^1.6.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.20.0"
+        "react-router-dom": "6.30.4"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "6.4.2",
@@ -1020,9 +1020,10 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4962,11 +4963,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -4976,12 +4978,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/services/webui/package.json
+++ b/services/webui/package.json
@@ -12,10 +12,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "axios": "^1.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.20.0",
-    "axios": "^1.6.2"
+    "react-router-dom": "6.30.4"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "6.4.2",

--- a/services/webui/src/contexts/AuthContext.jsx
+++ b/services/webui/src/contexts/AuthContext.jsx
@@ -75,6 +75,9 @@ export function AuthProvider({ children }) {
   );
 }
 
+// Context + companion hook pattern; splitting `useAuth` into its own file
+// would only hurt readability for no HMR benefit in this small context file.
+// eslint-disable-next-line react-refresh/only-export-components -- deliberate
 export function useAuth() {
   const context = useContext(AuthContext);
   if (!context) {

--- a/services/webui/src/pages/UsageAnalytics.jsx
+++ b/services/webui/src/pages/UsageAnalytics.jsx
@@ -26,6 +26,7 @@ function UsageAnalytics() {
 
   useEffect(() => {
     fetchUsageData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const fetchUsageData = async () => {

--- a/services/webui/src/pages/VirtualKeys.jsx
+++ b/services/webui/src/pages/VirtualKeys.jsx
@@ -241,7 +241,7 @@ function VirtualKeys() {
         <div className="modal">
           <div className="modal-content key-created-modal">
             <h2>Key Created Successfully</h2>
-            <p>Please copy and save this key now. You won't be able to see it again.</p>
+            <p>Please copy and save this key now. You won&apos;t be able to see it again.</p>
             <div className="key-display-large">
               <div className="key-value">{createdKeyValue}</div>
               <button className="btn-primary" onClick={() => copyToClipboard(createdKeyValue)}>

--- a/services/webui/src/test/App.test.jsx
+++ b/services/webui/src/test/App.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import App from '../App';
 

--- a/services/webui/src/test/Dashboard.test.jsx
+++ b/services/webui/src/test/Dashboard.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Dashboard from '../pages/Dashboard';
 
 // Mock CSS import

--- a/services/webui/src/test/VirtualKeys.test.jsx
+++ b/services/webui/src/test/VirtualKeys.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import VirtualKeys from '../pages/VirtualKeys';
 
 // Mock CSS import
@@ -38,15 +38,41 @@ const mockKeys = [
 ];
 
 describe('VirtualKeys', () => {
+  // jsdom exposes `navigator.clipboard` as a getter-only accessor, so
+  // Object.assign(navigator, { clipboard: ... }) throws. Redefine the
+  // property instead, and restore the original descriptor afterward so
+  // the stub doesn't leak into other test files.
+  const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+    window.navigator,
+    'clipboard'
+  );
+
+  // `userEvent.setup()` installs its own navigator.clipboard stub
+  // (@testing-library/user-event/.../Clipboard.js attachClipboardStubToView),
+  // clobbering whatever mock was in place. Re-apply after every
+  // `userEvent.setup()` call in tests that assert on clipboard writes.
+  const mockClipboard = () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+      configurable: true,
+      writable: true,
+    });
+  };
+
   beforeEach(() => {
     vi.resetAllMocks();
     axios.get.mockResolvedValue({ data: { keys: mockKeys } });
-    // Mock clipboard API
-    Object.assign(navigator, {
-      clipboard: {
-        writeText: vi.fn().mockResolvedValue(undefined),
-      },
-    });
+    mockClipboard();
+  });
+
+  afterEach(() => {
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor);
+    } else {
+      delete navigator.clipboard;
+    }
   });
 
   it('shows loading state initially', async () => {
@@ -198,6 +224,7 @@ describe('VirtualKeys', () => {
       .mockResolvedValueOnce({ data: { keys: mockKeys } });
 
     const user = userEvent.setup();
+    mockClipboard(); // re-apply: userEvent.setup() replaces navigator.clipboard
     render(<VirtualKeys />);
 
     await waitFor(() => {
@@ -430,8 +457,6 @@ describe('VirtualKeys', () => {
   });
 
   it('handles clipboard copy failure gracefully', async () => {
-    navigator.clipboard.writeText = vi.fn().mockRejectedValue(new Error('Clipboard denied'));
-
     const newKeyValue = 'wk-copy-fail-test';
     axios.post.mockResolvedValue({ data: { key: newKeyValue } });
     axios.get
@@ -439,6 +464,9 @@ describe('VirtualKeys', () => {
       .mockResolvedValueOnce({ data: { keys: mockKeys } });
 
     const user = userEvent.setup();
+    // userEvent.setup() replaces navigator.clipboard with its own stub, so
+    // the rejecting mock must be installed after setup(), not before.
+    navigator.clipboard.writeText = vi.fn().mockRejectedValue(new Error('Clipboard denied'));
     render(<VirtualKeys />);
 
     await waitFor(() => {


### PR DESCRIPTION
Two commits, both `services/webui`.

## 1. `react-router-dom` → exact `6.30.4`

Was `^6.20.0`, resolving to 6.30.3 — inside an open react-router advisory range. 6.30.4 is the 6.x patch (same bump Dependabot proposed in #65), bringing `react-router` 6.30.4 and `@remix-run/router` 1.23.3. Verified the lockfile diff moved **only** those three packages.

Pinned exact rather than re-caretting — the caret is what let the resolved version drift into the advisory range, and `^`/`~` are forbidden by the frontend standard.

> Two newer advisories (`GHSA-wrjc-x8rr-h8h6`, `GHSA-337j-9hxr-rhxg`) remain. Neither has a 6.x patch; npm's only fix is `react-router-dom@7.18.2`, a major migration. Not attempted here.

## 2. Pre-existing lint + test failures

**19 lint errors → 0. 17 of 193 failing tests → 193/193.** I verified both failure sets reproduce on a clean `release/v0.2.X` checkout with none of these changes present, so they are genuinely pre-existing.

They survived because **CI never ran webui's lint or tests** — the workflow only docker-builds this service. #73 starts fixing that; a follow-up wires webui in.

The test failures were two stacked problems, not the one I expected: jsdom exposes `navigator.clipboard` as a getter-only accessor so `Object.assign` threw, *and* `userEvent.setup()` installs its own clipboard stub that silently overwrites any mock set beforehand. Fixed with `Object.defineProperty`, re-applied after each `setup()`, with the original descriptor restored in `afterEach` so nothing leaks into the other 11 test files. No test skipped or deleted.

Lint fixes are scoped, not blanket suppressions: `src/test/**` gets the `node` env (tests legitimately stub `global.fetch`), two unused imports dropped, one JSX apostrophe escaped. The two `eslint-disable-next-line` comments follow the convention already at `Memory.jsx:32`.

## Known gap, not fixed here

`vitest.config.js` enforces 90% coverage; the suite is at **75.6% functions / 85.86% branches**, so `npm test` still exits 1 on the gate even with all 193 tests passing. That predates this branch (`2431aeb2`) and closing it means writing new tests.

## Verification

| Command | Result |
|---|---|
| `npm run lint` | **exit 0** — 0 errors, 0 warnings |
| `npx vitest run` | **193/193 passing** |
| `npm run build` | pass |
| `npm test` | tests pass; exits 1 on the pre-existing coverage gate above |

🤖 Generated with [Claude Code](https://claude.com/claude-code)