### PR TITLE
ci: run webui lint, tests and build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -104,6 +104,44 @@ jobs:
         flags: unittests
         name: codecov-umbrella
 
+  # services/webui was only ever docker-built, so its JS lint and test suites
+  # never ran anywhere. They rotted unnoticed to 19 lint errors and 17 failing
+  # tests before anyone looked. This job exists so that cannot recur.
+  test-webui:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./services/webui
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+    - name: Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      with:
+        node-version: '24'
+        cache: npm
+        cache-dependency-path: services/webui/package-lock.json
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Lint
+      run: npm run lint
+
+    # Deliberately `vitest run` and not `npm test`: the npm script adds
+    # --coverage, and vitest.config.js enforces a 90% threshold the suite does
+    # not currently meet (75.6% functions / 85.86% branches, predating
+    # 2431aeb2). Gating on coverage today would wire this job in permanently
+    # red. Tests themselves must pass; raising coverage to the 90% standard and
+    # switching this step to `npm test` is tracked separately.
+    - name: Unit tests
+      run: npx vitest run
+
+    - name: Build
+      run: npm run build
+
   build-platform:
     needs: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes the last of the three CI holes found while preparing #60. Depends on #74 (merged), which made webui green in the first place.

## Why

`services/webui` was only ever docker-built — its ESLint and vitest suites ran **nowhere**. They rotted unnoticed to 19 lint errors and 17 failing tests, which #74 just repaired. Without this job the same thing happens again.

## The job

`npm ci` → `npm run lint` → `npx vitest run` → `npm run build`, on Node 24.

**`npx vitest run`, not `npm test`, on purpose.** The npm script adds `--coverage`, and `vitest.config.js` enforces a 90% threshold the suite does not meet (**75.6% functions / 85.86% branches**, predating `2431aeb2`). Gating on coverage today would wire this job in permanently red. Tests must pass; raising coverage to the 90% standard and flipping this step to `npm test` is separate work.

## Verified on this branch's merged base

| Check | Result |
|---|---|
| `npm run lint` | exit 0 — 0 errors, 0 warnings |
| `npx vitest run` | **193 passed (193)** |
| `npm run build` | pass |

## Notes

- `setup-node` reuses the exact commit already pinned in `deploy-cloudflare-pages.yml` rather than a newly chosen SHA.
- No `github.event.*` interpolation anywhere in the job — no workflow-injection surface.
- Node 24 here matches the house standard and local dev, but the **webui Dockerfile still builds on `node:18`, EOL since April 2025**. Worth bumping, but that changes the shipped image so it belongs in its own PR. The existing `build-platform` job still builds the image on every PR, so a runtime divergence would still be caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)