### PR TITLE
fix(webui): build on Node 24 with npm ci instead of EOL Node 18

### DIFF
--- a/services/webui/Dockerfile
+++ b/services/webui/Dockerfile
@@ -1,15 +1,18 @@
 # Multi-stage Dockerfile for WaddleAI WebUI
 # React frontend served via nginx
 
-FROM node:18-bookworm-slim@sha256:f9ab18e354e6855ae56ef2b290dd225c1e51a564f87584b9bd21dd651838830e AS builder
+FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS builder
 
 WORKDIR /app
 
-# Copy package files
-COPY package.json package-lock.json* ./
+# Lockfile is required, not optional — npm ci refuses to run without it, and a
+# glob that silently tolerates its absence would defeat the point.
+COPY package.json package-lock.json ./
 
-# Install dependencies
-RUN npm install
+# npm ci, not npm install: install can resolve versions that differ from the
+# lockfile, so a dependency pinned for a security fix is not guaranteed to be
+# the one that ships. ci installs exactly what the lockfile records.
+RUN npm ci
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
Two defects in the webui image build.

## 1. `npm install` did not honour the lockfile — the security fix wasn't guaranteed to ship

The builder ran `npm install`, which can resolve versions differing from `package-lock.json`. So the `react-router-dom` → 6.30.4 pin from #74, which closed a GHSA advisory, was **not guaranteed to be what actually shipped in the image**.

`npm ci` installs exactly what the lockfile records. The lockfile `COPY` also stops being an optional glob (`package-lock.json*`), since `npm ci` requires it and a glob that tolerates its absence defeats the purpose.

## 2. Node 18 is EOL

End-of-life since April 2025 — an unmaintained runtime getting no security patches, which the standards list as a red flag. Moved to `node:24-bookworm-slim`, digest-pinned.

Node **24**, not 26, so the image, the new `test-webui` CI job, and local development all sit on one version. 26 is the eventual target — 24 is explicitly acceptable while migrating.

## Verification — actually built and run

| Check | Result |
|---|---|
| `docker build` | exit 0 |
| Builder stage node | `v24.19.0` |
| Installed versions | `react-router 6.30.4`, `react-router-dom 6.30.4`, `@remix-run/router 1.23.3` — matches the lockfile |
| Final image `GET /` | **HTTP 200**, serves `index.html` |
| Container user | `uid=1000(waddleai)` — non-root |

The digest was resolved with `docker buildx imagetools inspect`, not copied from memory: `sha256:3638d9a6…` is a multi-arch index covering `linux/amd64` and `linux/arm64`.

## Not changed

The nginx runtime stage and its `curl`-based `HEALTHCHECK` stay as-is. The frontend standard prefers an Express runtime and forbids `curl` in healthchecks, but that's an architectural change to how the service is served — its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)