### PR TITLE
test(webui): raise coverage above the 90% gate and enforce it in CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -130,14 +130,12 @@ jobs:
     - name: Lint
       run: npm run lint
 
-    # Deliberately `vitest run` and not `npm test`: the npm script adds
-    # --coverage, and vitest.config.js enforces a 90% threshold the suite does
-    # not currently meet (75.6% functions / 85.86% branches, predating
-    # 2431aeb2). Gating on coverage today would wire this job in permanently
-    # red. Tests themselves must pass; raising coverage to the 90% standard and
-    # switching this step to `npm test` is tracked separately.
-    - name: Unit tests
-      run: npx vitest run
+    # `npm test` runs vitest with --coverage, so this step enforces the 90%
+    # thresholds in vitest.config.js as well as test outcomes. It ran as bare
+    # `vitest run` only while coverage sat below the gate; the suite now clears
+    # it (100 statements / 99.55 branches / 100 functions / 100 lines).
+    - name: Unit tests and coverage
+      run: npm test
 
     - name: Build
       run: npm run build

--- a/services/webui/src/test/AuthContext.test.jsx
+++ b/services/webui/src/test/AuthContext.test.jsx
@@ -202,6 +202,49 @@ describe('AuthContext', () => {
     expect(loginResult).toEqual({ success: false, error: 'Invalid credentials' });
   });
 
+  it('login() falls back to "Login failed" when the error response has no message field', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false }); // initial verify
+
+    let loginResult;
+    function LoginTester() {
+      const { login, loading } = useAuth();
+      return (
+        <div>
+          <div data-testid="loading">{String(loading)}</div>
+          <button
+            data-testid="do-login"
+            onClick={async () => {
+              loginResult = await login('user', 'wrong');
+            }}
+          >
+            go
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <AuthProvider>
+        <LoginTester />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading')).toHaveTextContent('false');
+    });
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    });
+
+    await act(async () => {
+      screen.getByTestId('do-login').click();
+    });
+
+    expect(loginResult).toEqual({ success: false, error: 'Login failed' });
+  });
+
   it('login() returns success: false with Network error on fetch exception', async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: false }); // initial verify
 

--- a/services/webui/src/test/Dashboard.test.jsx
+++ b/services/webui/src/test/Dashboard.test.jsx
@@ -383,6 +383,28 @@ describe('Dashboard', () => {
     });
   });
 
+  it('renders the default activity icon for an unrecognized activity type', async () => {
+    const recentActivity = {
+      activity: [{ type: 'unknown_type', title: 'Mystery event', timestamp: new Date().toISOString() }],
+    };
+
+    axios.get.mockImplementation((url) => {
+      if (url === '/api/v1/usage/summary') return Promise.resolve({ data: mockSummaryData });
+      if (url === '/api/v1/ailb/status') return Promise.resolve({ data: { providers: [] } });
+      if (url.startsWith('/api/v1/usage/recent')) return Promise.resolve({ data: recentActivity });
+    });
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Mystery event')).toBeInTheDocument();
+    });
+
+    const iconEl = document.querySelector('.activity-icon.info');
+    expect(iconEl).toBeInTheDocument();
+    expect(iconEl).toHaveTextContent('ℹ️');
+  });
+
   it('renders activity provider and token info in detail line', async () => {
     setupSuccessfulAxios();
     render(<Dashboard />);
@@ -392,5 +414,63 @@ describe('Dashboard', () => {
       expect(screen.getByText(/Provider: openai/)).toBeInTheDocument();
       expect(screen.getByText(/1,500 tokens/)).toBeInTheDocument();
     });
+  });
+
+  it('falls back to empty lists when providers/activity fields are absent from the API response', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === '/api/v1/usage/summary') return Promise.resolve({ data: mockSummaryData });
+      if (url === '/api/v1/ailb/status') return Promise.resolve({ data: {} });
+      if (url.startsWith('/api/v1/usage/recent')) return Promise.resolve({ data: {} });
+    });
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No recent activity')).toBeInTheDocument();
+      expect(screen.getByText('No providers configured')).toBeInTheDocument();
+    });
+  });
+
+  it('shows 0 fallback for total requests and tokens when API omits those fields', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === '/api/v1/usage/summary')
+        return Promise.resolve({ data: { total_cost: 0, active_keys: 0 } });
+      if (url === '/api/v1/ailb/status') return Promise.resolve({ data: { providers: [] } });
+      if (url.startsWith('/api/v1/usage/recent')) return Promise.resolve({ data: { activity: [] } });
+    });
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No providers configured')).toBeInTheDocument();
+    });
+
+    const requestsCard = screen.getByText('Total Requests').closest('.stat-card');
+    expect(requestsCard).toHaveTextContent('0');
+
+    const tokensCard = screen.getByText('Tokens Processed').closest('.stat-card');
+    expect(tokensCard).toHaveTextContent('0');
+  });
+
+  it('shows "unknown" health badge for a provider missing health_status', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === '/api/v1/usage/summary') return Promise.resolve({ data: mockSummaryData });
+      if (url === '/api/v1/ailb/status')
+        return Promise.resolve({ data: { providers: [{ name: 'No Health Provider' }] } });
+      if (url.startsWith('/api/v1/usage/recent')) return Promise.resolve({ data: { activity: [] } });
+    });
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No Health Provider')).toBeInTheDocument();
+    });
+
+    const badge = screen
+      .getByText('No Health Provider')
+      .closest('.provider-item')
+      .querySelector('.health-badge');
+    expect(badge).toHaveClass('unknown');
+    expect(badge).toHaveTextContent('unknown');
   });
 });

--- a/services/webui/src/test/Memory.test.jsx
+++ b/services/webui/src/test/Memory.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Memory from '../pages/Memory';
 
@@ -196,5 +196,116 @@ describe('Memory page', () => {
     expect(checkboxes[0]).toBeChecked();
     fireEvent.click(checkboxes[0]);
     expect(checkboxes[0]).not.toBeChecked();
+  });
+
+  it('falls back to organization id 1 when input is cleared to a falsy value', async () => {
+    render(<Memory />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Organization ID')).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByLabelText('Organization ID'), { target: { value: '0' } });
+    expect(screen.getByLabelText('Organization ID')).toHaveValue(1);
+  });
+
+  it('updates memory max messages and similarity threshold fields', async () => {
+    render(<Memory />);
+    await waitFor(() => {
+      expect(document.getElementById('memory-max-messages')).toBeInTheDocument();
+    });
+
+    fireEvent.change(document.getElementById('memory-max-messages'), { target: { value: '50' } });
+    expect(document.getElementById('memory-max-messages')).toHaveValue(50);
+
+    fireEvent.change(document.getElementById('memory-similarity'), { target: { value: '0.9' } });
+    expect(document.getElementById('memory-similarity')).toHaveValue(0.9);
+  });
+
+  it('toggles rag enabled checkbox and updates rag collection, top k, and similarity fields', async () => {
+    render(<Memory />);
+    await waitFor(() => {
+      expect(document.getElementById('rag-collection')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[1]).not.toBeChecked();
+    fireEvent.click(checkboxes[1]);
+    expect(checkboxes[1]).toBeChecked();
+
+    fireEvent.change(document.getElementById('rag-collection'), { target: { value: 'docs' } });
+    expect(document.getElementById('rag-collection')).toHaveValue('docs');
+
+    fireEvent.change(document.getElementById('rag-top-k'), { target: { value: '10' } });
+    expect(document.getElementById('rag-top-k')).toHaveValue(10);
+
+    fireEvent.change(document.getElementById('rag-similarity'), { target: { value: '0.8' } });
+    expect(document.getElementById('rag-similarity')).toHaveValue(0.8);
+  });
+
+  it('updates embedding backend, model, host, and dimensions fields', async () => {
+    render(<Memory />);
+    await waitFor(() => {
+      expect(document.getElementById('embedding-backend')).toBeInTheDocument();
+    });
+
+    fireEvent.change(document.getElementById('embedding-backend'), { target: { value: 'openai' } });
+    expect(document.getElementById('embedding-backend')).toHaveValue('openai');
+
+    fireEvent.change(document.getElementById('embedding-model'), {
+      target: { value: 'text-embedding-3-small' },
+    });
+    expect(document.getElementById('embedding-model')).toHaveValue('text-embedding-3-small');
+
+    fireEvent.change(document.getElementById('embedding-host'), {
+      target: { value: 'http://localhost:9999' },
+    });
+    expect(document.getElementById('embedding-host')).toHaveValue('http://localhost:9999');
+
+    fireEvent.change(document.getElementById('embedding-dimensions'), { target: { value: '1536' } });
+    expect(document.getElementById('embedding-dimensions')).toHaveValue(1536);
+  });
+
+  it('dismisses success alert when close button clicked', async () => {
+    axios.post.mockResolvedValue({ data: { status: 'updated' } });
+    render(<Memory />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Memory Configuration' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Memory Configuration' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Memory configuration saved successfully')).toBeInTheDocument();
+    });
+
+    const successAlert = screen.getByText('Memory configuration saved successfully').closest('.alert');
+    fireEvent.click(successAlert.querySelector('button'));
+    expect(screen.queryByText('Memory configuration saved successfully')).not.toBeInTheDocument();
+  });
+
+  it('clears success message automatically after 3 seconds', async () => {
+    axios.post.mockResolvedValue({ data: { status: 'updated' } });
+    render(<Memory />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Memory Configuration' })).toBeInTheDocument();
+    });
+
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Memory Configuration' }));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Memory configuration saved successfully')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(screen.queryByText('Memory configuration saved successfully')).not.toBeInTheDocument();
+    vi.useRealTimers();
   });
 });

--- a/services/webui/src/test/OllamaDeployments.test.jsx
+++ b/services/webui/src/test/OllamaDeployments.test.jsx
@@ -332,6 +332,117 @@ describe('OllamaDeployments', () => {
     });
   });
 
+  it('updates deployment type, GPU count, and auto-start toggle in create form', async () => {
+    render(<OllamaDeployments />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '+ New Deployment' })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: '+ New Deployment' }));
+
+    const typeSelect = screen.getByRole('combobox');
+    fireEvent.change(typeSelect, { target: { value: 'kubernetes' } });
+    expect(typeSelect).toHaveValue('kubernetes');
+
+    const gpuInput = screen.getByDisplayValue('1');
+    fireEvent.change(gpuInput, { target: { value: '4' } });
+    expect(screen.getByDisplayValue('4')).toBeInTheDocument();
+
+    const autoStartCheckbox = screen.getByRole('checkbox');
+    expect(autoStartCheckbox).toBeChecked();
+    fireEvent.click(autoStartCheckbox);
+    expect(autoStartCheckbox).not.toBeChecked();
+  });
+
+  it('falls back to an empty deployments list when API response omits the field', async () => {
+    axios.get.mockResolvedValue({ data: {} });
+    render(<OllamaDeployments />);
+    await waitFor(() => {
+      expect(screen.getByText('No Ollama deployments configured')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error when create deployment fails without response error field', async () => {
+    axios.post.mockRejectedValue(new Error('boom'));
+
+    const user = userEvent.setup();
+    render(<OllamaDeployments />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '+ New Deployment' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '+ New Deployment' }));
+    await user.type(screen.getByPlaceholderText('ollama-node-1'), 'x');
+    await user.type(screen.getByPlaceholderText('http://ollama-node-1:11434'), 'http://x:11434');
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create deployment')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error when delete deployment fails without response error field', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    axios.delete.mockRejectedValue(new Error('boom'));
+
+    render(<OllamaDeployments />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to delete deployment')).toBeInTheDocument();
+    });
+
+    confirmSpy.mockRestore();
+  });
+
+  it('shows generic error when pull model fails without response error field', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('llama3.2');
+    axios.post.mockRejectedValue(new Error('boom'));
+
+    render(<OllamaDeployments />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Pull Model' })).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Pull Model' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to pull model')).toBeInTheDocument();
+    });
+
+    promptSpy.mockRestore();
+  });
+
+  it('renders "latest" as fallback model tag when a model has no tag', async () => {
+    axios.get.mockResolvedValue({
+      data: {
+        deployments: [
+          {
+            id: 5,
+            name: 'tagless-node',
+            endpoint_url: 'http://tagless:11434',
+            deployment_type: 'docker',
+            status: 'running',
+            health_status: 'healthy',
+            gpu_config: { gpu_count: 1 },
+            models: [{ id: 9, model_name: 'phi3' }],
+          },
+        ],
+      },
+    });
+
+    render(<OllamaDeployments />);
+    await waitFor(() => {
+      expect(screen.getByText('phi3:latest')).toBeInTheDocument();
+    });
+  });
+
   it('shows "unknown" when health_status is absent', async () => {
     axios.get.mockResolvedValue({
       data: {

--- a/services/webui/src/test/Providers.test.jsx
+++ b/services/webui/src/test/Providers.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Providers from '../pages/Providers';
@@ -454,5 +454,194 @@ describe('Providers page', () => {
     fireEvent.click(successAlert.querySelector('button'));
 
     expect(screen.queryByText('Connection test successful!')).not.toBeInTheDocument();
+  });
+
+  it('renders the ollama provider icon', async () => {
+    axios.get.mockResolvedValue({
+      data: { providers: [{ id: 3, name: 'Local Ollama', provider_type: 'ollama', is_active: true }] },
+    });
+    render(<Providers />);
+
+    await waitFor(() => {
+      expect(screen.getByText('🦙')).toBeInTheDocument();
+    });
+  });
+
+  it('renders the generic icon for an unrecognized provider type', async () => {
+    axios.get.mockResolvedValue({
+      data: { providers: [{ id: 4, name: 'Custom LLM', provider_type: 'custom', is_active: true }] },
+    });
+    render(<Providers />);
+
+    await waitFor(() => {
+      expect(screen.getByText('🔌')).toBeInTheDocument();
+    });
+  });
+
+  it('falls back to an empty providers list when API response omits the field', async () => {
+    axios.get.mockResolvedValue({ data: {} });
+    render(<Providers />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No AI providers configured')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error when create provider fails without response error field', async () => {
+    axios.post.mockRejectedValue(new Error('boom'));
+
+    const user = userEvent.setup();
+    render(<Providers />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '+ Add Provider' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Provider' }));
+    await user.type(screen.getByPlaceholderText('My OpenAI Provider'), 'X');
+    await user.type(screen.getByPlaceholderText('sk-...'), 'sk-x');
+    fireEvent.click(screen.getByRole('button', { name: 'Add Provider' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create provider')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error when update provider fails without response error field', async () => {
+    axios.put.mockRejectedValue(new Error('boom'));
+
+    render(<Providers />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Edit' })).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Update Provider' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to update provider')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error when delete provider fails without response error field', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    axios.delete.mockRejectedValue(new Error('boom'));
+
+    render(<Providers />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to delete provider')).toBeInTheDocument();
+    });
+
+    confirmSpy.mockRestore();
+  });
+
+  it('shows generic error when connection test throws without response error field', async () => {
+    axios.post.mockRejectedValue(new Error('boom'));
+
+    render(<Providers />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Test' })).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Test' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Connection test failed')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error when sync to AILB fails without response error field', async () => {
+    axios.post.mockRejectedValue(new Error('boom'));
+
+    render(<Providers />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Sync to AILB' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sync to AILB' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to sync to AILB')).toBeInTheDocument();
+    });
+  });
+
+  it('opens edit form with default endpoint and priority when provider has neither set', async () => {
+    axios.get.mockResolvedValue({
+      data: { providers: [{ id: 5, name: 'Bare Provider', provider_type: 'openai', is_active: true }] },
+    });
+    render(<Providers />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(screen.getByText('Edit Provider')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('https://api.openai.com/v1')).toHaveValue('');
+    expect(screen.getByDisplayValue('1')).toBeInTheDocument();
+  });
+
+  it('updates provider type, endpoint URL, priority, and active toggle in the form', async () => {
+    render(<Providers />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '+ Add Provider' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Add Provider' }));
+
+    const typeSelect = screen.getByDisplayValue('OpenAI');
+    fireEvent.change(typeSelect, { target: { value: 'anthropic' } });
+    expect(typeSelect).toHaveValue('anthropic');
+
+    const endpointInput = screen.getByPlaceholderText('https://api.openai.com/v1');
+    fireEvent.change(endpointInput, { target: { value: 'https://custom.example.com' } });
+    expect(endpointInput).toHaveValue('https://custom.example.com');
+
+    const priorityInput = screen.getByDisplayValue('1');
+    fireEvent.change(priorityInput, { target: { value: '5' } });
+    expect(screen.getByDisplayValue('5')).toBeInTheDocument();
+
+    const activeCheckbox = screen.getByRole('checkbox');
+    expect(activeCheckbox).toBeChecked();
+    fireEvent.click(activeCheckbox);
+    expect(activeCheckbox).not.toBeChecked();
+  });
+
+  it('clears both success and error 3 seconds after a connection test', async () => {
+    axios.post.mockResolvedValue({ data: { success: true } });
+    render(<Providers />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Test' })).toHaveLength(2);
+    });
+
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Test' })[0]);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Connection test successful!')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(screen.queryByText('Connection test successful!')).not.toBeInTheDocument();
+    vi.useRealTimers();
   });
 });

--- a/services/webui/src/test/Routing.test.jsx
+++ b/services/webui/src/test/Routing.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Routing from '../pages/Routing';
@@ -220,5 +220,110 @@ describe('Routing page', () => {
 
     const alternatives = screen.getByText('Alternative Models:').closest('p');
     expect(alternatives).toHaveTextContent('Alternative Models:');
+  });
+
+  it('changes routing LLM model via select', async () => {
+    render(<Routing />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Routing LLM Model')).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByLabelText('Routing LLM Model'), { target: { value: 'gpt-4o-mini' } });
+    expect(screen.getByLabelText('Routing LLM Model')).toHaveValue('gpt-4o-mini');
+  });
+
+  it('updates routing instructions textarea', async () => {
+    render(<Routing />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Routing Instructions')).toBeInTheDocument();
+    });
+    fireEvent.change(screen.getByLabelText('Routing Instructions'), { target: { value: 'New instructions' } });
+    expect(screen.getByLabelText('Routing Instructions')).toHaveValue('New instructions');
+  });
+
+  it('dismisses success alert when close button clicked', async () => {
+    axios.post.mockResolvedValue({ data: { status: 'success', data: {} } });
+    render(<Routing />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Routing Configuration' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Routing Configuration' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Routing configuration saved successfully')).toBeInTheDocument();
+    });
+
+    const successAlert = screen.getByText('Routing configuration saved successfully').closest('.alert');
+    fireEvent.click(successAlert.querySelector('button'));
+    expect(screen.queryByText('Routing configuration saved successfully')).not.toBeInTheDocument();
+  });
+
+  it('clears success message automatically after 3 seconds', async () => {
+    axios.post.mockResolvedValue({ data: { status: 'success', data: {} } });
+    render(<Routing />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Routing Configuration' })).toBeInTheDocument();
+    });
+
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Routing Configuration' }));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Routing configuration saved successfully')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(screen.queryByText('Routing configuration saved successfully')).not.toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it('falls back to empty instructions object when response.data.data is entirely missing', async () => {
+    axios.get.mockResolvedValue({ data: { status: 'success' } });
+    render(<Routing />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Routing LLM Model')).toHaveValue('llama3.2:1b');
+    });
+    expect(screen.getByLabelText('Routing Instructions')).toHaveValue('');
+  });
+
+  it('shows generic error when save fails without response error field', async () => {
+    axios.post.mockRejectedValue(new Error('Network error'));
+    render(<Routing />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Routing Configuration' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Routing Configuration' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to save routing configuration')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error when test routing fails without response error field', async () => {
+    axios.post.mockRejectedValue(new Error('Network error'));
+
+    const user = userEvent.setup();
+    render(<Routing />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Test Prompt')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText('Test Prompt'), 'x');
+    fireEvent.click(screen.getByRole('button', { name: 'Test Routing' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Routing test failed')).toBeInTheDocument();
+    });
   });
 });

--- a/services/webui/src/test/UsageAnalytics.test.jsx
+++ b/services/webui/src/test/UsageAnalytics.test.jsx
@@ -331,4 +331,133 @@ describe('UsageAnalytics', () => {
     fireEvent.change(startDateInput, { target: { value: '2025-01-01' } });
     expect(startDateInput.value).toBe('2025-01-01');
   });
+
+  it('computes a non-zero percentage change when a previous period value is present', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === '/api/v1/usage/summary')
+        return Promise.resolve({ data: { ...mockSummaryData, previous_requests: 1000 } });
+      if (url === '/api/v1/usage') return Promise.resolve({ data: mockUsageData });
+    });
+
+    render(<UsageAnalytics />);
+
+    await waitFor(() => {
+      // total_requests: 3200, previous_requests: 1000 -> (3200-1000)/1000*100 = 220.0
+      expect(screen.getByText('+220.0% from last period')).toBeInTheDocument();
+    });
+  });
+
+  it('includes start_date and end_date filter params when Apply Filters is clicked with dates set', async () => {
+    setupSuccessfulAxios();
+    render(<UsageAnalytics />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Usage Analytics')).toBeInTheDocument();
+    });
+
+    const startDateInput = screen
+      .getAllByDisplayValue('')
+      .find((el) => el.getAttribute('type') === 'date');
+    fireEvent.change(startDateInput, { target: { value: '2025-01-01' } });
+
+    const endDateInput = screen
+      .getAllByDisplayValue('')
+      .find((el) => el.getAttribute('type') === 'date');
+    fireEvent.change(endDateInput, { target: { value: '2025-02-01' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply Filters' }));
+
+    await waitFor(() => {
+      const calls = axios.get.mock.calls;
+      const usageCall = calls.find(
+        ([url, config]) =>
+          url === '/api/v1/usage' &&
+          config?.params?.start_date === '2025-01-01' &&
+          config?.params?.end_date === '2025-02-01'
+      );
+      expect(usageCall).toBeDefined();
+    });
+  });
+
+  it('renders a zero-height bar when every item in the chart has a zero value', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === '/api/v1/usage/summary') return Promise.resolve({ data: mockSummaryData });
+      if (url === '/api/v1/usage')
+        return Promise.resolve({
+          data: {
+            ...mockUsageData,
+            by_provider: [{ provider: 'idle-provider', requests: 0, tokens: 0, cost: 0 }],
+          },
+        });
+    });
+
+    render(<UsageAnalytics />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle('idle-provider: 0')).toBeInTheDocument();
+    });
+
+    const bar = screen.getByTitle('idle-provider: 0');
+    expect(bar).toHaveStyle({ height: '0%' });
+  });
+
+  it('shows fallback values in breakdown table when name/requests/tokens/cost fields are missing', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === '/api/v1/usage/summary') return Promise.resolve({ data: mockSummaryData });
+      if (url === '/api/v1/usage')
+        return Promise.resolve({ data: { ...mockUsageData, by_provider: [{}] } });
+    });
+
+    render(<UsageAnalytics />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unknown')).toBeInTheDocument();
+    });
+
+    const row = screen.getByText('Unknown').closest('tr');
+    const cells = row.querySelectorAll('td');
+    expect(cells[1]).toHaveTextContent('0');
+    expect(cells[2]).toHaveTextContent('0');
+    expect(cells[3]).toHaveTextContent('$0.0000');
+    expect(cells[4]).toHaveTextContent('0.0%');
+  });
+
+  it('shows 0 fallback for total requests and tokens stat cards when API omits those fields', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === '/api/v1/usage/summary')
+        return Promise.resolve({ data: { total_cost: 5, active_keys: 2 } });
+      if (url === '/api/v1/usage') return Promise.resolve({ data: mockUsageData });
+    });
+
+    render(<UsageAnalytics />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Usage Analytics')).toBeInTheDocument();
+    });
+
+    const requestsCard = screen.getByText('Total Requests').closest('.stat-card');
+    expect(requestsCard).toHaveTextContent('0');
+
+    const tokensCard = screen.getByText('Total Tokens').closest('.stat-card');
+    expect(tokensCard).toHaveTextContent('0');
+  });
+
+  it('formats bar chart values over one million with an M suffix', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url === '/api/v1/usage/summary') return Promise.resolve({ data: mockSummaryData });
+      if (url === '/api/v1/usage')
+        return Promise.resolve({
+          data: {
+            ...mockUsageData,
+            by_provider: [{ provider: 'openai', requests: 2000, tokens: 3200000, cost: 18.0 }],
+          },
+        });
+    });
+
+    render(<UsageAnalytics />);
+
+    await waitFor(() => {
+      expect(screen.getByText('3.20M')).toBeInTheDocument();
+    });
+  });
 });

--- a/services/webui/src/test/VirtualKeys.test.jsx
+++ b/services/webui/src/test/VirtualKeys.test.jsx
@@ -456,6 +456,193 @@ describe('VirtualKeys', () => {
     });
   });
 
+  it('updates allowed models, providers, rate limits, budget, and expiration fields in create form', async () => {
+    render(<VirtualKeys />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '+ Create New Key' })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: '+ Create New Key' }));
+
+    fireEvent.change(screen.getByPlaceholderText('gpt-4, claude-3-opus-20240229'), {
+      target: { value: 'gpt-4' },
+    });
+    expect(screen.getByPlaceholderText('gpt-4, claude-3-opus-20240229')).toHaveValue('gpt-4');
+
+    fireEvent.change(screen.getByPlaceholderText('openai, anthropic, ollama'), {
+      target: { value: 'openai' },
+    });
+    expect(screen.getByPlaceholderText('openai, anthropic, ollama')).toHaveValue('openai');
+
+    fireEvent.change(screen.getByDisplayValue('60'), { target: { value: '120' } });
+    expect(screen.getByDisplayValue('120')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByDisplayValue('10000'), { target: { value: '20000' } });
+    expect(screen.getByDisplayValue('20000')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByDisplayValue('100'), { target: { value: '250' } });
+    expect(screen.getByDisplayValue('250')).toBeInTheDocument();
+
+    const expiresInput = document.querySelector('input[type="datetime-local"]');
+    fireEvent.change(expiresInput, { target: { value: '2026-12-31T23:59' } });
+    expect(expiresInput).toHaveValue('2026-12-31T23:59');
+  });
+
+  it('dismisses success alert when close button clicked', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    axios.delete.mockResolvedValue({ data: {} });
+    render(<VirtualKeys />);
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('button[title="Revoke key"]').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(document.querySelectorAll('button[title="Revoke key"]')[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Key revoked successfully')).toBeInTheDocument();
+    });
+
+    const successAlert = screen.getByText('Key revoked successfully').closest('.alert');
+    fireEvent.click(successAlert.querySelector('button'));
+    expect(screen.queryByText('Key revoked successfully')).not.toBeInTheDocument();
+
+    confirmSpy.mockRestore();
+  });
+
+  it('copies key prefix to clipboard via the per-row copy button', async () => {
+    render(<VirtualKeys />);
+    await waitFor(() => {
+      expect(screen.getByText('Production Key')).toBeInTheDocument();
+    });
+
+    const copyButtons = document.querySelectorAll('button.copy-btn');
+    fireEvent.click(copyButtons[0]);
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('wk-prod-12345678');
+    });
+  });
+
+  it('renders empty key text when key_prefix is missing', async () => {
+    axios.get.mockResolvedValue({ data: { keys: [{ ...mockKeys[0], key_prefix: undefined }] } });
+    render(<VirtualKeys />);
+    await waitFor(() => {
+      expect(screen.getByText('Production Key')).toBeInTheDocument();
+    });
+    expect(document.querySelector('.key-text')).toHaveTextContent('');
+  });
+
+  it('renders $0.00 budget fallback when budget_used/budget_limit are missing', async () => {
+    axios.get.mockResolvedValue({
+      data: { keys: [{ ...mockKeys[0], budget_used: undefined, budget_limit: undefined }] },
+    });
+    render(<VirtualKeys />);
+    await waitFor(() => {
+      expect(screen.getByText('$0.00 / $0.00')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error when revoke fails without response error field', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    axios.delete.mockRejectedValue(new Error('boom'));
+
+    render(<VirtualKeys />);
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('button[title="Revoke key"]').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(document.querySelectorAll('button[title="Revoke key"]')[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to revoke key')).toBeInTheDocument();
+    });
+
+    confirmSpy.mockRestore();
+  });
+
+  it('shows generic error when rotate fails without response error field', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    axios.post.mockRejectedValue(new Error('boom'));
+
+    render(<VirtualKeys />);
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('button[title="Rotate key"]').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(document.querySelectorAll('button[title="Rotate key"]')[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to rotate key')).toBeInTheDocument();
+    });
+
+    confirmSpy.mockRestore();
+  });
+
+  it('submits create form with allowed models/providers and sends parsed array payload', async () => {
+    axios.post.mockResolvedValue({ data: { key: 'wk-full-payload' } });
+    axios.get
+      .mockResolvedValueOnce({ data: { keys: mockKeys } })
+      .mockResolvedValueOnce({ data: { keys: mockKeys } });
+
+    const user = userEvent.setup();
+    render(<VirtualKeys />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '+ Create New Key' })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: '+ Create New Key' }));
+
+    await user.type(screen.getByPlaceholderText('Production API Key'), 'Full Payload Key');
+    fireEvent.change(screen.getByPlaceholderText('gpt-4, claude-3-opus-20240229'), {
+      target: { value: 'gpt-4, claude-3-opus' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('openai, anthropic, ollama'), {
+      target: { value: 'openai, anthropic' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Key' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Key Created Successfully')).toBeInTheDocument();
+    });
+
+    expect(axios.post).toHaveBeenCalledWith(
+      '/api/v1/keys',
+      expect.objectContaining({
+        allowed_models: ['gpt-4', 'claude-3-opus'],
+        allowed_providers: ['openai', 'anthropic'],
+      })
+    );
+  });
+
+  it('shows generic error when create key fails without response error field', async () => {
+    axios.post.mockRejectedValue(new Error('boom'));
+
+    const user = userEvent.setup();
+    render(<VirtualKeys />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '+ Create New Key' })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: '+ Create New Key' }));
+    await user.type(screen.getByPlaceholderText('Production API Key'), 'fail-generic');
+    fireEvent.click(screen.getByRole('button', { name: 'Create Key' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create virtual key')).toBeInTheDocument();
+    });
+  });
+
+  it('falls back to an empty keys list when API response omits the field', async () => {
+    axios.get.mockResolvedValue({ data: {} });
+    render(<VirtualKeys />);
+    await waitFor(() => {
+      expect(screen.getByText('No virtual keys created yet')).toBeInTheDocument();
+    });
+  });
+
   it('handles clipboard copy failure gracefully', async () => {
     const newKeyValue = 'wk-copy-fail-test';
     axios.post.mockResolvedValue({ data: { key: newKeyValue } });


### PR DESCRIPTION
Closes the last standards gap flagged in #74 and #75.

## Problem

`vitest.config.js` has required **90% on lines, branches, functions and statements** for some time, but the suite sat at **75.6% functions / 85.86% branches**. So `npm test` exited 1 even with every test passing, and the `test-webui` job added in #75 had to run bare `vitest run` — gating on outcomes but *not* coverage.

## Change

**46 tests added across 8 existing test files**, aimed at the genuinely uncovered paths rather than padding: rejected-axios error branches, empty-state and null-coalescing fallbacks, form-field `onChange` handlers, success-banner dismissal timers, and conditional icon/formatter branches.

```
All files | 100 statements | 99.55 branches | 100 functions | 100 lines
244 tests passing (up from 193)
```

With the gate cleared, the CI step goes back to `npm test`, so **coverage is now enforced on every PR** rather than merely measured.

## Guardrails — verified, not asserted

| | |
|---|---|
| Thresholds lowered? | **No** — `git diff` on `vitest.config.js` is empty |
| Production source changed? | **No** — `git diff` on `src/pages`, `src/components`, `src/contexts` is empty |
| Tests skipped/deleted? | **No** — no `.skip`, `xit`, or `it.todo` anywhere |
| Vacuous assertions? | **None** — no `expect(true)`-style filler |

## Verification (run independently on this branch)

| Command | Result |
|---|---|
| `npm run lint` | exit 0 — 0 errors, 0 warnings |
| `npm test` | **exit 0** — 12 files, **244/244**, all four thresholds met |

## Two branches intentionally left uncovered

They're **unreachable, not untested**:

- `UsageAnalytics.jsx:39` keys off a `filters.model` state that no UI control ever sets — a dead/unwired filter.
- `UsageAnalytics.jsx:70` is an empty-data guard in `getMaxValue` whose only caller, `renderBarChart`, already early-returns before reaching it.

Both predate this branch. Making them reachable would mean changing production code, which is out of scope here — they're worth a follow-up look as possible dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)