### PR TITLE
chore(deps): hold the Python base image on 3.13 and fix the management path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,9 +49,20 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    ignore:
+      # Hold the base image on the 3.13 line. The house standard is Python
+      # 3.13.x and CI runs 3.13, so a 3.14 image would put the container ahead
+      # of both and diverge from what the test job actually exercises.
+      # Patch and minor updates within 3.13 still come through normally.
+      # Remove this once the standard moves to 3.14.
+      - dependency-name: "python"
+        versions: [">=3.14"]
 
+  # Path is services/management, not management — the service moved during the
+  # Phase-1 consolidation. The old entry pointed at a directory that no longer
+  # exists, so Dockerfile updates for this service were silently never scanned.
   - package-ecosystem: "docker"
-    directory: "/management"
+    directory: "/services/management"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -63,3 +74,7 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    ignore:
+      # Same 3.13 hold as the proxy image above.
+      - dependency-name: "python"
+        versions: [">=3.14"]


### PR DESCRIPTION
## The ignore rule

Dependabot keeps proposing `python:3.14-slim-bookworm` for both service images (#79, #80). The house standard is **Python 3.13.x** and CI runs 3.13, so taking 3.14 would put the containers ahead of both — and ahead of the version the test job actually exercises.

```yaml
    ignore:
      - dependency-name: "python"
        versions: [">=3.14"]
```

Applied to both docker entries. Patch and minor updates *within* 3.13 still come through normally. Remove this when the standard moves to 3.14.

## The bug it exposed

The management docker entry pointed at **`/management`** — deleted during the Phase-1 consolidation; the service is `services/management` now.

Dependabot has been scanning a directory that doesn't exist, so **Dockerfile updates for the control plane were silently never proposed**. An ignore rule attached to that path would have been just as inert, which is why both are fixed together rather than separately.

## Verified

| Check | Result |
|---|---|
| Config parses as Dependabot v2 | ok |
| Both ignore rules well-formed (`dependency-name` + `versions`) | ok |
| `/proxy` contains a Dockerfile | yes |
| `/services/management` contains a Dockerfile | yes (previously `/management` — did not) |

## Two more defects found in this file, deliberately NOT fixed here

Both are real, both confirmed by API lookup, and both change how much noise the PR queue gets — which is a scheduling decision rather than a correctness one:

1. **`assignees: waddleai-bot` and `reviewers: waddleai-team` both return 404.** Neither the user nor the team exists, so every Dependabot PR has gone out unassigned and unreviewed.
2. **The `pip` ecosystem is configured only at `/`**, but `requirements.in` also lives in `proxy/`, `services/management/`, `services/penguincode/`, `docs/` and `docs/docs-site/`. Five trees have never received version-update PRs — the pip PRs we've seen all came from the root manifest, plus security updates, which run regardless of config.

Wiring up those five directories would immediately open a fresh wave of PRs, which is the opposite of what's wanted while we're closing 22 of them out. Happy to do it as a follow-up on your say-so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)