### PR TITLE
ci: add CodeQL analysis for Python, JS/TS and Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,66 @@
+name: CodeQL
+
+# The org ruleset "main protections" carries a code_scanning rule, but nothing
+# in this repo ever produced code scanning results for a pull request: the only
+# SARIF upload lives in docker-build.yml's security-scan job, which is gated on
+# `github.event_name != 'pull_request'` and therefore always skips on PRs. The
+# rule consequently sat at "Waiting for Code Scanning results" forever and
+# blocked release merges into main. This workflow supplies those results.
+
+on:
+  push:
+    branches: [main, 'release/**']
+  pull_request:
+    branches: [main, 'release/**']
+  schedule:
+    # Weekly re-scan so advisories published after a merge still surface.
+    - cron: '0 8 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # build-mode: none is correct for interpreted languages — CodeQL reads
+          # the source directly, so there is nothing to compile and no build to
+          # break. Go is deliberately absent; see the note below.
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
+        with:
+          category: "/language:${{ matrix.language }}"
+
+# Go is not analysed here yet. It is a compiled language, so CodeQL needs
+# autobuild or a manual build, and this repo has two independent modules
+# (shared/go_libs and services/penguincode/shared/go_libs) that autobuild would
+# have to be verified against before it can be trusted not to fail the job.
+# Go is also being phased out in favour of Rust per the language standard, so
+# the 36 .go files here are library code rather than a shipped service. Adding
+# it belongs in its own change, where a failing autobuild can be diagnosed
+# without holding up the scanning that does work.


### PR DESCRIPTION
## Why

The org ruleset **"main protections"** carries a `code_scanning` rule, but **nothing in this repo has ever produced code scanning results for a pull request.**

The only SARIF upload lives in `docker-build.yml`'s `security-scan` job, which is gated on `github.event_name != 'pull_request'` — which is why every check list on every PR in this repo shows it as `skipping`. CodeQL default setup is `not-configured` as well, so nothing filled the gap from that side either. The only analyses on record come from a `security-scan` run on `v0.1.x` back in May.

Result: the rule sits permanently at *"Waiting for Code Scanning results"*, and it's **one of the four things blocking #60** from merging into `main`.

## What this adds

| Language | Files | Build mode |
|---|---|---|
| `python` | 319 | `none` |
| `javascript-typescript` | 137 `.ts`/`.tsx` + 37 `.js`/`.jsx` (excl. `node_modules`) | `none` |
| `actions` | 4 workflows | `none` |

`build-mode: none` is correct for interpreted languages — CodeQL reads the source directly, so there's no build step that can break the job.

Runs on push and PR for `main` and `release/**`, plus a weekly cron so advisories published after a merge still surface.

## Go deliberately excluded

It's compiled, so CodeQL needs `autobuild` or a manual build, and this repo has **two independent modules** (`shared/go_libs`, `services/penguincode/shared/go_libs`) that autobuild would need verifying against before it could be trusted not to fail the job. Go is also being phased out in favour of Rust per the language standard, and the 36 `.go` files here are library code, not a shipped service.

Adding it belongs in its own change, where a failing autobuild can be diagnosed without holding up the scanning that does work.

## Supply chain

Both actions pinned to full commit SHAs resolved from the API — `github/codeql-action`'s `v4` is an *annotated* tag and was dereferenced to its underlying commit `5595ccaf`. No `github.event.*` interpolation anywhere, so no workflow-injection surface.

## What this does and doesn't unblock on #60

It should satisfy the `code_scanning` rule. It does **not** address the other three blockers:
- `required_signatures` — 77 commits carry no signature
- `require_last_push_approval` + `require_code_owner_review` — the only other code owner has read access
- the org ruleset's bypass entry is `{"actor_id": null, "actor_type": "OrganizationAdmin"}`, which resolves to nobody — which is why org-admin override isn't working

Separately: `code_coverage` is also a rule on that ruleset. CodeQL is static analysis, not coverage, so it won't satisfy that one — that needs a coverage provider wired up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)