### PR TITLE
fix(db): convert remaining raw pydal usage to penguin-dal

### DIFF
--- a/proxy/apps/proxy_server/main.py
+++ b/proxy/apps/proxy_server/main.py
@@ -145,14 +145,12 @@ class ProxyServer:
 
         # Initialize database (pgvector-enabled PostgreSQL primary).
         #
-        # get_db() (shared.database.models) is the raw-PyDAL connection that
+        # get_db() (shared.database.models) is the penguin-dal connection that
         # RBACManager, TokenManager, PromptSecurityScanner, ContentFilter, and
         # LLMConnectionManager are all actually written against (synchronous
         # `self.db(query).select()`/`.update_record()` calls -- see the module
-        # docstring in shared/database/models.py). The previous
-        # `from penguin_dal import get_dal` import does not exist anywhere in
-        # penguin-dal and never has; this line has never worked in any
-        # environment. `migrate=True` only in contract-test mode, so the
+        # docstring in shared/database/models.py). penguin-dal exposes DAL/Field
+        # directly, not a `get_dal` factory. `migrate=True` only in contract-test mode, so the
         # harness's empty per-session sqlite file gets real tables; production
         # keeps migrate=False (Alembic/management remains schema authority).
         database_url = os.getenv("DATABASE_URL", "postgresql://waddleai:password@localhost:5432/waddleai")

--- a/scripts/seed_security_rag.py
+++ b/scripts/seed_security_rag.py
@@ -25,7 +25,7 @@ _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
-from pydal import DAL  # noqa: E402
+from penguin_dal import DAL  # noqa: E402
 
 from shared.utils.embedding_manager import EmbeddingConfig, EmbeddingManager  # noqa: E402
 from shared.utils.rag_integration import Document, PgvectorRAGStore  # noqa: E402

--- a/shared/database/models.py
+++ b/shared/database/models.py
@@ -6,7 +6,7 @@ Shared database models for both proxy and management servers
 import os
 from datetime import date, datetime
 
-from pydal import DAL, Field
+from penguin_dal import DAL, Field
 
 
 def get_db(db_uri=None, migrate=False):
@@ -23,12 +23,12 @@ def get_db(db_uri=None, migrate=False):
     if db_uri is None:
         db_uri = os.getenv("DATABASE_URL", "sqlite://waddleai.db")
 
-    # fake_migrate_all always False: that flag skips real CREATE TABLE/ALTER
-    # and only (re)writes PyDAL's .table fingerprint files -- it is for
-    # adopting an already-existing external schema, not for actually creating
-    # one. migrate=True must produce real tables (contract-test harness runs
-    # against a brand-new, empty sqlite file).
-    db = DAL(db_uri, migrate=migrate, fake_migrate_all=False)
+    # penguin_dal.DAL has no fake_migrate_all param (PyDAL-only concept: it
+    # skips CREATE TABLE/ALTER and only rewrites PyDAL's .table fingerprint
+    # files for adopting an already-existing external schema). penguin_dal's
+    # define_table() always does CREATE TABLE IF NOT EXISTS, matching the
+    # fake_migrate_all=False behavior this call previously requested.
+    db = DAL(db_uri, migrate=migrate)
     define_tables(db)
     return db
 
@@ -39,41 +39,39 @@ def define_tables(db):
     # Organizations for Multi-tenancy
     db.define_table(
         "organizations",
-        Field("name", unique=True, required=True),
+        Field("name", unique=True, notnull=True),
         Field("description", "text"),
         Field("token_quota_monthly", "integer", default=1000000),
         Field("token_quota_daily", "integer", default=100000),
         Field("default_model", "string"),  # Default model for organization
         Field("enabled", "boolean", default=True),
         Field("created_at", "datetime", default=datetime.utcnow),
-        format="%(name)s",
     )
 
     # Users and Authentication
     db.define_table(
         "users",
-        Field("username", unique=True, required=True),
-        Field("email", unique=True, required=True),
-        Field("password_hash", "password", required=True),
-        Field("role", "string", required=True),  # admin, resource_manager, reporter, user
-        Field("organization_id", "reference organizations", required=True),
+        Field("username", unique=True, notnull=True),
+        Field("email", unique=True, notnull=True),
+        Field("password_hash", "password", notnull=True),
+        Field("role", "string", notnull=True),  # admin, resource_manager, reporter, user
+        Field("organization_id", "reference organizations", notnull=True),
         Field("managed_orgs", "list:reference organizations"),  # For resource managers
         Field("created_at", "datetime", default=datetime.utcnow),
         Field("token_quota_monthly", "integer", default=100000),
         Field("token_quota_daily", "integer", default=10000),
         Field("default_model", "string"),  # Default model for user
         Field("enabled", "boolean", default=True),
-        format="%(username)s",
     )
 
     # API Keys with Usage Limits
     db.define_table(
         "api_keys",
-        Field("key_id", unique=True, required=True),
-        Field("key_hash", "password", required=True),  # Hashed API key
-        Field("user_id", "reference users", required=True),
-        Field("organization_id", "reference organizations", required=True),
-        Field("name", "string", required=True),  # Human readable name
+        Field("key_id", unique=True, notnull=True),
+        Field("key_hash", "password", notnull=True),  # Hashed API key
+        Field("user_id", "reference users", notnull=True),
+        Field("organization_id", "reference organizations", notnull=True),
+        Field("name", "string", notnull=True),  # Human readable name
         Field("token_quota_monthly", "integer"),  # Override user quota
         Field("token_quota_daily", "integer"),  # Override user quota
         Field("rate_limit_rpm", "integer", default=60),  # Requests per minute
@@ -85,7 +83,6 @@ def define_tables(db):
         Field("permissions", "json"),  # Scoped permissions
         Field("allowed_endpoints", "list:string"),  # Endpoint restrictions
         Field("api_access_level", "string"),  # admin_api, management_api, proxy_api
-        format="%(name)s",
     )
 
     # Connection Links (LLM Providers)
@@ -96,23 +93,22 @@ def define_tables(db):
     # See: services/management/app/models_sqlalchemy.py for the canonical schema.
     db.define_table(
         "connection_links",
-        Field("name", unique=True, required=True),
-        Field("provider", "string", required=True),  # ollama, anthropic, openai
-        Field("endpoint_url", required=True),
+        Field("name", unique=True, notnull=True),
+        Field("provider", "string", notnull=True),  # ollama, anthropic, openai
+        Field("endpoint_url", notnull=True),
         Field("api_key", "password"),
         Field("model_list", "json"),
         Field("rate_limits", "json"),
         Field("enabled", "boolean", default=True),
         Field("tls_config", "json"),
         Field("management_capabilities", "json"),  # For Ollama: pull, remove, list
-        format="%(name)s",
     )
 
     # Ollama Model Registry
     db.define_table(
         "ollama_models",
-        Field("link_id", "reference connection_links", required=True),
-        Field("model_name", required=True),
+        Field("link_id", "reference connection_links", notnull=True),
+        Field("model_name", notnull=True),
         Field("model_tag", default="latest"),
         Field("status", "string", default="unknown"),  # available, pulling, failed, removed
         Field("size_bytes", "bigint"),
@@ -124,7 +120,7 @@ def define_tables(db):
     # Routing Rules
     db.define_table(
         "routing_rules",
-        Field("name", required=True),
+        Field("name", notnull=True),
         Field("routing_llm_id", "reference connection_links"),
         Field("conditions", "json"),  # request patterns, user criteria
         Field("target_links", "list:reference connection_links"),
@@ -135,7 +131,7 @@ def define_tables(db):
     # Conversation Memory Configurations
     db.define_table(
         "conversation_memory_configs",
-        Field("name", required=True),
+        Field("name", notnull=True),
         Field("provider", "string", default="mem0"),  # mem0, chromadb
         Field("connection_string"),
         Field("api_key", "password"),
@@ -148,7 +144,7 @@ def define_tables(db):
     # RAG/Knowledge Base Configurations
     db.define_table(
         "rag_configs",
-        Field("name", required=True),
+        Field("name", notnull=True),
         Field("provider", "string", default="supabase"),  # supabase, qdrant, chromadb
         Field("connection_string"),
         Field("api_key", "password"),
@@ -163,10 +159,10 @@ def define_tables(db):
     # Token Conversion Rates (LLM tokens to WaddleAI tokens)
     db.define_table(
         "token_conversion_rates",
-        Field("provider", "string", required=True),  # openai, anthropic, ollama
-        Field("model", "string", required=True),
-        Field("input_rate", "double", required=True),  # LLM tokens per WaddleAI token
-        Field("output_rate", "double", required=True),  # LLM tokens per WaddleAI token
+        Field("provider", "string", notnull=True),  # openai, anthropic, ollama
+        Field("model", "string", notnull=True),
+        Field("input_rate", "double", notnull=True),  # LLM tokens per WaddleAI token
+        Field("output_rate", "double", notnull=True),  # LLM tokens per WaddleAI token
         Field("base_cost_per_waddleai_token", "double", default=0.001),
         Field("effective_date", "datetime", default=datetime.utcnow),
         Field("enabled", "boolean", default=True),
@@ -175,9 +171,9 @@ def define_tables(db):
     # Token Usage Tracking
     db.define_table(
         "token_usage",
-        Field("api_key_id", "reference api_keys", required=True),
-        Field("user_id", "reference users", required=True),
-        Field("organization_id", "reference organizations", required=True),
+        Field("api_key_id", "reference api_keys", notnull=True),
+        Field("user_id", "reference users", notnull=True),
+        Field("organization_id", "reference organizations", notnull=True),
         Field("date", "date", default=date.today),
         # WaddleAI Tokens (normalized usage units)
         Field("waddleai_tokens", "integer", default=0),
@@ -192,10 +188,10 @@ def define_tables(db):
     # Real-time Usage Cache (for quota enforcement)
     db.define_table(
         "usage_cache",
-        Field("api_key_id", "reference api_keys", required=True),
-        Field("organization_id", "reference organizations", required=True),
-        Field("period", "string", required=True),  # daily, monthly
-        Field("period_start", "datetime", required=True),
+        Field("api_key_id", "reference api_keys", notnull=True),
+        Field("organization_id", "reference organizations", notnull=True),
+        Field("period", "string", notnull=True),  # daily, monthly
+        Field("period_start", "datetime", notnull=True),
         Field("waddleai_tokens_used", "integer", default=0),
         Field("llm_tokens_used", "json"),  # Per-LLM breakdown
         Field("requests_made", "integer", default=0),
@@ -246,11 +242,11 @@ def define_tables(db):
     # Content Filter Rules
     db.define_table(
         "content_filter_rules",
-        Field("name", "string", required=True),
+        Field("name", "string", notnull=True),
         Field("description", "text"),
-        Field("rule_type", "string", required=True),  # 'builtin_pii', 'custom_string', 'custom_regex'
+        Field("rule_type", "string", notnull=True),  # 'builtin_pii', 'custom_string', 'custom_regex'
         Field("target", "string", default="both"),  # 'input', 'output', 'both'
-        Field("pattern", "text", required=True),
+        Field("pattern", "text", notnull=True),
         Field("action", "string", default="log"),  # 'block', 'redact', 'log'
         Field("redact_with", "string", default="[REDACTED]"),
         Field("enabled", "boolean", default=True),
@@ -264,12 +260,12 @@ def define_tables(db):
     db.define_table(
         "content_filter_audit_log",
         Field("timestamp", "datetime", default=datetime.utcnow),
-        Field("phase", "string", required=True),  # 'input', 'output'
+        Field("phase", "string", notnull=True),  # 'input', 'output'
         Field("user_id", "reference users"),
         Field("organization_id", "reference organizations"),
         Field("api_key_id", "reference api_keys"),
         Field("ip_address", "string"),
-        Field("action_taken", "string", required=True),  # 'allow', 'block', 'redact', 'log'
+        Field("action_taken", "string", notnull=True),  # 'allow', 'block', 'redact', 'log'
         Field("violations_json", "json"),
         Field("text_sample", "text"),  # First 200 chars for audit
         Field("auditor_used", "boolean", default=False),
@@ -280,7 +276,7 @@ def define_tables(db):
     # Content Filter Configuration (key-value store for auditor settings)
     db.define_table(
         "content_filter_config",
-        Field("key", "string", required=True),
+        Field("key", "string", notnull=True),
         Field("value", "text"),
         Field("organization_id", "reference organizations"),
         Field("created_by", "reference users"),

--- a/shared/utils/memory_integration.py
+++ b/shared/utils/memory_integration.py
@@ -1100,7 +1100,7 @@ class ReadReplicaPool:
         """
         import os
 
-        from pydal import DAL
+        from penguin_dal import DAL
 
         urls_raw = os.getenv(replica_url_env, "").strip()
         if not urls_raw:


### PR DESCRIPTION
`penguin-dal` is mandatory for all runtime database operations, but three modules still imported `pydal` directly:

| File | Line |
|---|---|
| `shared/database/models.py` | 9 |
| `shared/utils/memory_integration.py` | 1103 |
| `scripts/seed_security_rag.py` | 28 |

This was also an **undeclared dependency** — `pydal` appears in no `requirements.in` and resolved only transitively through `penguin-dal`, so those imports worked by accident.

## penguin-dal is not a drop-in

Three call-site incompatibilities had to be resolved rather than swapped blind. Each would have raised `TypeError` at import or table-definition time:

| Call | Problem | Resolution |
|---|---|---|
| `DAL(..., fake_migrate_all=False)` | No such kwarg — PyDAL-only concept for adopting an existing schema without emitting DDL | Dropped. penguin-dal's `define_table()` is already `CREATE TABLE IF NOT EXISTS`, which is what the flag was asking for |
| `Field(..., required=True)` **×36** | No such kwarg | → `notnull=True` |
| `define_table(..., format="%(name)s")` ×4 | `**kwargs` go straight to SQLAlchemy `Table()`, which rejects unknown keys | Dropped — a PyDAL row-display hint with no consumer in this repo |

### The `required` → `notnull` change is a real semantic shift, not a rename

PyDAL's `required` validates at the **DAL layer**; `notnull` is a **database constraint**. Worth stating plainly rather than burying:

- **Inert in production** — `get_db()` is called with `migrate=False` there, and Alembic remains the schema authority (see the comment at `proxy/apps/proxy_server/main.py:148`). No DDL is emitted.
- It only takes effect in **contract-test mode**, against a throwaway per-session sqlite file.
- `models.py` used **no `IS_*` validators**, so no validation behaviour was lost.

## Verified against a matched baseline

Same interpreter, same ignores, run on the unmodified branch and on this one:

| Suite | Baseline | This branch |
|---|---|---|
| unit | 1065 passed, 4 skipped | **1065 passed, 4 skipped** |
| contract | 33 passed, 46 errors | **33 passed, 46 errors** |

Identical. No regression.

⚠️ The excluded unit files and those contract errors are **pre-existing local breakage**, reproduced on the unmodified release branch: an `opentelemetry` exporter version skew in this machine's user site-packages raises `ImportError: cannot import name '_create_exp_backoff_generator'`, which `chromadb` imports transitively. CI installs from `requirements.txt` in a clean container and is the real gate — watch `test (3.13)` here.

## Unchanged, deliberately

Thread-safety. `proxy/apps/proxy_server/main.py` still holds one shared `db` instance created at startup rather than a thread-local, which its own comments describe as deliberate. That predates this change and isn't restructured here.

Also corrects the comment above that call site, which called `get_db()` "the raw-PyDAL connection" and referenced a `penguin_dal.get_dal` factory that doesn't exist.

## Out of scope

`services/penguincode/tests/conftest.py:169` also imports `pydal`, but penguincode is a separate vendored product and its fixtures aren't ours to change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)