### PR TITLE
fix(models): converge model defaults and drop the unpullable gemma4:2b

### DIFF
--- a/services/management/app/api/v1/routing_matrix.py
+++ b/services/management/app/api/v1/routing_matrix.py
@@ -33,7 +33,10 @@ routing_matrix_bp = Blueprint("routing_matrix", __name__, url_prefix="/api/v1/ro
 # Defaults mirror the legacy management plane's fallback text exactly, so
 # behavior is unchanged for callers that never configured routing instructions.
 _DEFAULT_ROUTING_INSTRUCTIONS = "No routing instructions configured"
-_DEFAULT_ROUTING_LLM = "gemma4:2b"
+# Matches shared/utils/request_router.py. This was "gemma4:2b", which is not a
+# pullable tag — Gemma 4 publishes e2b/e4b/12b/26b/31b and has no 2b, so the
+# default could never resolve. e2b is the smallest (2.3B effective params).
+_DEFAULT_ROUTING_LLM = "gemma4:e2b"
 
 # Default routing matrix spec used by the /seed endpoint
 DEFAULT_ROUTING_MATRIX: List[Dict[str, Any]] = [

--- a/shared/security/content_filter.py
+++ b/shared/security/content_filter.py
@@ -214,7 +214,13 @@ class ContentFilter:
         self,
         db: Any,
         ollama_base_url: str = "http://localhost:11434",
-        auditor_model: str = "llama3.2:3b",
+        # shieldgemma:2b, matching the only call site
+        # (proxy/apps/proxy_server/main.py, SECURITY_AUDITOR_MODEL). This was
+        # llama3.2:3b — a general chat model, not a safety classifier — so any
+        # caller relying on the default got materially different behaviour from
+        # the proxy. ShieldGemma is text-only by design; image and audio need
+        # their own classifiers rather than this one.
+        auditor_model: str = "shieldgemma:2b",
     ) -> None:
         """
         Initialize content filter.

--- a/shared/utils/request_router.py
+++ b/shared/utils/request_router.py
@@ -77,7 +77,11 @@ class LLMRequestRouter:
         self.breaker_cooldown = timedelta(minutes=5)
 
         # Routing LLM configuration
-        self.routing_llm_model = os.getenv("ROUTING_LLM", "llama3.2:1b")
+        # gemma4:e2b, matching services/management's _DEFAULT_ROUTING_LLM.
+        # Note the tag: Gemma 4 publishes e2b/e4b/12b/26b/31b and has NO 2b, so
+        # "gemma4:2b" is not pullable. e2b is the smallest (2.3B effective).
+        # Gemma 4 is Apache-2.0, unlike Gemma 1-3's custom Terms of Use.
+        self.routing_llm_model = os.getenv("ROUTING_LLM", "gemma4:e2b")
         self.use_intelligent_routing = os.getenv("USE_INTELLIGENT_ROUTING", "true").lower() == "true"
 
         # RAG configuration

--- a/tests/contract/snapshots/mgmt_routing_config_instructions.json
+++ b/tests/contract/snapshots/mgmt_routing_config_instructions.json
@@ -2,7 +2,7 @@
   "body": {
     "data": {
       "instructions": "No routing instructions configured",
-      "routing_llm": "gemma4:2b"
+      "routing_llm": "gemma4:e2b"
     },
     "meta": {
       "timestamp": "<VOLATILE>"


### PR DESCRIPTION
Four places declared defaults for the two utility models, with **three different values, one of which could never resolve**:

| Location | Setting | Was | Now |
|---|---|---|---|
| `shared/utils/request_router.py:80` | `ROUTING_LLM` | `llama3.2:1b` | `gemma4:e2b` |
| `services/.../routing_matrix.py:36` | `_DEFAULT_ROUTING_LLM` | **`gemma4:2b`** ❌ | `gemma4:e2b` |
| `proxy/.../main.py:180` | `SECURITY_AUDITOR_MODEL` | `shieldgemma:2b` | unchanged |
| `shared/security/content_filter.py:217` | `auditor_model` | `llama3.2:3b` | `shieldgemma:2b` |

## The two real bugs

**`gemma4:2b` does not exist.** Gemma 4 publishes `e2b/e4b/12b/26b/31b` — there is no `2b` tag — so `ollama pull gemma4:2b` fails and that default has never been usable. `e2b` (2.3B effective) is the smallest.

**The content filter's constructor defaulted to `llama3.2:3b`** — a general chat model, not a safety classifier — while its only call site passes `shieldgemma:2b`. Any caller relying on the class default got materially different *safety* behaviour from the proxy.

## Staying on ShieldGemma 1 deliberately

ShieldGemma 2 is a **4B image-only** classifier built on Gemma 3. It cannot classify text at all, and isn't published to Ollama (it uses task-specific probability heads rather than a chat interface). Substituting it would **disable** text filtering rather than upgrade it.

Image and audio need their own classifiers — a separate change, specced alongside this one.

## Licence note

Gemma 4 is **Apache 2.0**, unlike Gemma 1–3's custom Terms of Use — verified against Google's own terms page, which now states *"For Gemma 4 terms, see the Gemma 4 license"* → `/gemma/apache_2`. That removes the licence objection motivating the spec's dual-default pattern for this model.

## Contract snapshot updated

`mgmt_routing_config_instructions.json` asserted the old `gemma4:2b`. It **caught the change** — which is what it's for — and is updated to `gemma4:e2b`.

## Embedding defaults deliberately NOT converged

I proposed this earlier and was wrong; it would have corrupted vector search.

| Subsystem | Model | Serving | Dims |
|---|---|---|---|
| `rag_integration.py`, `memory_integration.py` | `all-MiniLM-L6-v2` | in-process `SentenceTransformer` | 384 |
| `embedding_manager.py`, AILB memory | `nomic-embed-text` | Ollama | 768 |

`rag_integration.py:317` hardcodes `self.vector_size = 384`. Repointing `rag_configs` at a 768-dim model would produce a dimension mismatch.

> ⚠️ Separate latent bug, logged not fixed: `rag_configs.embedding_model` is user-configurable while `vector_size` is hardcoded 384 — so **any** non-384-dim choice silently breaks.

## Verification

| Suite | Baseline | This branch |
|---|---|---|
| unit | 1065 passed, 4 skipped | **identical** |
| contract | 33 passed, 46 errors | **identical** |

The excluded files and contract errors are a pre-existing local `opentelemetry` version skew, reproduced on unmodified `release/v0.2.X`. CI is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)