### PR TITLE
spec/docs: provider-qualified model strings, and correct the header docs

### DIFF
--- a/docs/api/openai-compatible.md
+++ b/docs/api/openai-compatible.md
@@ -52,13 +52,37 @@ curl https://your-waddleai-proxy.com/v1/chat/completions \
 | `stop` | string/array | No | Stop sequences |
 | `stream` | boolean | No | Whether to stream responses |
 
+#### Selecting a provider — provider-qualified model strings
+
+Prefix the `model` field with a provider name to pin **both** the provider and the model:
+
+```python
+model="anthropic:claude-opus-5-1m"   # this model, from Anthropic directly
+model="bedrock:claude-opus-5-1m"     # the same model, via AWS Bedrock
+model="ollama:gemma4:e2b"            # local Ollama
+model="gemma4:e2b"                   # no provider pinned — WaddleAI routes
+```
+
+This matters because naming a model does not determine who serves it. The same Claude model is reachable through Anthropic direct, AWS Bedrock and GCP Vertex, each with different data residency, contractual terms, quota pools and pricing. Without a pin, WaddleAI chooses.
+
+It works in the plain `model` field rather than a header, so any OpenAI-compatible SDK supports it with no special handling.
+
+**Parsing**: the prefix is treated as a provider **only if it exactly matches a known provider** — `openai`, `anthropic`, `ollama`, `llamacpp`, `gemini`, `bedrock`, `azure_openai`, `cohere`, `xai` — and only the first colon is split on. Otherwise the whole string is the model name. That rule is why `gemma4:e2b` still resolves as a model: Ollama tags contain colons natively, and there is no provider called `gemma4`.
+
+**A pin disables substitution.** If the pinned provider is unavailable the request fails with a typed error rather than being served by another provider — pinning is usually a data-residency or contractual decision, and silently substituting would fail open on exactly that constraint. Org allow-lists and capability checks still apply; a pin cannot reach a provider your org is not permitted to use.
+
+> **Status:** specified, not yet implemented. See the platform spec §7.2 Stage 0. Today only the model name is honoured (see `X-Preferred-Model` below); the provider is chosen by the router.
+
 #### WaddleAI-Specific Headers
 
-| Header | Description |
-|--------|-------------|
-| `X-WaddleAI-Route` | Force routing to specific provider (e.g., "openai", "anthropic") |
-| `X-WaddleAI-Memory` | Enable conversation memory with session ID |
-| `X-WaddleAI-Security` | Override security policy ("strict", "balanced", "permissive") |
+| Header | Status | Description |
+|--------|--------|-------------|
+| `X-Preferred-Model` | **Implemented** | Overrides the `model` field in the request body |
+| `X-Session-ID` | **Implemented** | Conversation/session identifier (also accepted as `session_id` in the body) |
+| `X-WaddleAI-Tool-Type` | Specified, not implemented | Declares the tool type explicitly, skipping classification (spec §7.2 stage 0) |
+| `X-WaddleAI-Route` | ⚠️ **Not implemented** | Previously documented as forcing a provider. Nothing reads it. Use a provider-qualified model string instead — it is provider *and* model, and needs no custom header |
+| `X-WaddleAI-Memory` | ⚠️ **Not implemented** | Previously documented; nothing reads it |
+| `X-WaddleAI-Security` | ⚠️ **Not implemented** | Previously documented; nothing reads it. Security policy is resolved from `security_policies` scopes, not per-request |
 
 #### Response
 

--- a/docs/superpowers/specs/2026-07-09-waddleai-platform-spec.md
+++ b/docs/superpowers/specs/2026-07-09-waddleai-platform-spec.md
@@ -424,6 +424,18 @@ Org **policy filters and sorts** on top of both: allow-lists and tier caps filte
 ### 7.2 Decision cascade (cheapest first)
 
 - **Stage 0 — explicit model.** Client named a concrete model → resolve through `model_aliases`, honor exactly, subject to org allow-lists and the capability veto. **Admin-controlled aliasing**: alias rules (`gpt-4o` → local `mistral-large`; `claude-*` → policy X) are the migration lever that localizes existing tools without touching client config. Redirects always visible in `waddleai.routed_from`.
+
+  **Provider-qualified model strings.** A client may pin the provider as well as the model, in the plain `model` field: `anthropic:claude-opus-5-1m`, `bedrock:claude-opus-5-1m`, `ollama:gemma4:e2b`. This is deliberately *not* a header — it works through the standard OpenAI/Anthropic `model` field, so every SDK and every tool that cannot set custom headers gets it for free.
+
+  Pinning matters because model identity does not determine provider: the same Claude model is reachable via Anthropic direct, AWS Bedrock and GCP Vertex, with different data residency, contractual terms, quota pools and pricing. Naming only the model leaves that choice to the router.
+
+  **Parsing rule — a prefix is a provider only if it exactly matches a registered provider name** (`openai`, `anthropic`, `ollama`, `llamacpp`, `gemini`, `bedrock`, `azure_openai`, `cohere`, `xai`); split on the **first** colon only. Otherwise the entire string is the model name. This disambiguation is required, not cosmetic: Ollama tags contain colons natively, so a naive split would parse bare `gemma4:e2b` as provider `gemma4`, model `e2b`. Under this rule `gemma4:e2b` stays a model (no provider named `gemma4`) while `ollama:gemma4:e2b` splits correctly. Model names therefore MUST NOT collide with provider names; on collision the provider interpretation wins and registration of such a model is rejected.
+
+  **Order of resolution**: strip the provider prefix first (it is syntax), then resolve the remainder through `model_aliases`. If an alias resolves to a model the pinned provider does not serve, **fail fast** with the §5.3 typed error — do not silently honour one and drop the other.
+
+  **A provider pin disables substitution.** `provider_failover` (§7.3) MUST NOT substitute another provider when the pinned one is unavailable; the request fails with the taxonomy error instead. Pinning is most often done for data-residency, contractual or quota reasons, and silently serving from a different provider would fail open on precisely the constraint the pin expressed. The capability veto and org allow-lists still apply — a pin cannot reach a provider the org is not permitted to use, and cannot override a hard capability mismatch.
+
+  `waddleai.routed_from` records the pin, so a served response always shows whether the provider was chosen or demanded.
 - **Stage 1 — heuristics** (<1ms, no LLM): `routing_rules_v2(priority, match jsonb, action jsonb)` — determines tool type / route from cheap signals; target ~70% of `auto` requests.
 - **Stage 2 — classifier** (only when heuristics punt): structured JSON → assignment lookup → capability check.
 


### PR DESCRIPTION
## The question: does `X-WaddleAI-Route` include the model?

**No — and it doesn't exist.**

| Header | Documented | In code |
|---|---|---|
| `X-WaddleAI-Route` | "Force routing to specific provider" — **provider only** | **Never read** |
| `X-WaddleAI-Memory` | ✅ | **Never read** |
| `X-WaddleAI-Security` | ✅ | **Never read** |
| `X-Preferred-Model` | ❌ | **Implemented** (`main.py:693`) |
| `X-Session-ID` | ❌ | **Implemented** |

The docs advertised headers that don't exist while the code read headers nobody was told about.

Neither mechanism let a caller pin the **provider**. `route_request(model: str, …)` takes a model name and the router picks who serves it.

## Why that gap matters

`claude-opus-5-1m` is reachable via **Anthropic direct, AWS Bedrock, and GCP Vertex** — same model, different data residency, contractual terms, quota pools and pricing. Naming only the model leaves that choice to the router.

## The fix — provider-qualified model strings (§7.2 Stage 0)

```python
model="anthropic:claude-opus-5-1m"   # this model, from Anthropic
model="bedrock:claude-opus-5-1m"     # same model, via Bedrock
model="ollama:gemma4:e2b"            # local
model="gemma4:e2b"                   # unpinned — WaddleAI routes
```

In the **plain `model` field**, not a header — so every OpenAI-compatible SDK gets it for free, and tools that can't set custom headers aren't excluded.

### ⚠️ The parsing rule is load-bearing, not cosmetic

**Ollama tags contain colons natively.** Splitting naively on the first colon would read bare `gemma4:e2b` as provider `gemma4`, model `e2b`.

So: **a prefix is a provider only if it exactly matches a registered provider name** (`openai`, `anthropic`, `ollama`, `llamacpp`, `gemini`, `bedrock`, `azure_openai`, `cohere`, `xai`), splitting on the **first colon only**. Otherwise the whole string is the model. Model names must not collide with provider names; registration of such a model is rejected.

### Resolution order

Strip the provider prefix first (it's syntax), *then* resolve through `model_aliases`. If an alias resolves to a model the pinned provider doesn't serve → **fail fast**, don't honour one and drop the other.

### A pin disables substitution

`provider_failover` (§7.3) MUST NOT substitute when the pinned provider is unavailable — the request fails with the §5.3 typed error instead.

Pinning is normally a **data-residency or contractual** decision. Silently serving from a different provider would fail open on exactly the constraint the pin expressed. Org allow-lists and the capability veto still apply — a pin can't reach a provider the org may not use.

## Docs

The header table is rewritten with an explicit **status column** — implemented / specified / documented-but-never-existed — so the next reader isn't misled the way this one was.

## Verified

Every claim re-checked against code: `X-Preferred-Model` and `X-Session-ID` present, **no `X-WaddleAI-*` anywhere** in `proxy/`, `shared/` or `services/`, provider names matching the `ProviderType` enum, and §5.3/§7.2/§7.3 all resolving to real headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)