### PR TITLE
chore(security): scope bandit to production code, exclude tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,6 +107,14 @@ repos:
     hooks:
       - id: bandit
         stages: [pre-push]
+        # Bandit fails on ANY finding including Low, and B101 ("assert used")
+        # fires on every assert in the suite -- 113 of the 115 findings that
+        # blocked the first push after ruff adoption. B101 exists because
+        # asserts are stripped under `python -O`, which is a production
+        # concern; in tests the assert IS the contract. Same reasoning and
+        # same scope as the S101 per-file-ignore in pyproject.toml: tests are
+        # excluded, production code keeps the full ruleset at every severity.
+        exclude: ^tests/
 
   - repo: local
     hooks:


### PR DESCRIPTION
Companion to the `S101` scoping in #119. Same rule, different tool — ruff's `S101` and bandit's `B101` are the same check, and both were firing on every `assert` in the test suite.

## Problem

The bandit pre-push hook ran with no arguments, so it failed on **any** finding at **any** severity. On the first push after ruff adoption it reported 115 findings and blocked the push:

- **113 × B101** — "assert used", one per assert in the test files being pushed
- **2 × B105** — bandit flagging the `TEST_ONLY_JWT_SECRET` / `TEST_ONLY_PASSWORD` constants that had just been introduced *to make test credentials explicit and greppable*

So the hook penalised both writing tests and labelling test credentials clearly.

## Why B101 is not a real finding in tests

`B101` exists because `assert` statements are stripped when Python runs under `-O`, which makes them unsafe for enforcing invariants in **production** code. In a test suite the assert *is* the contract — there is no `-O` execution path, and nothing to strip.

## Verification that nothing real is hidden

Bandit over the changed **production** files reports zero issues at every severity:

```
Total issues (by severity):
    Undefined: 0    Low: 0    Medium: 0    High: 0
```

All 115 findings were in `tests/`. Production code keeps the full bandit ruleset at every severity — only `^tests/` is excluded.

This also matches the HIGH-only gating pass already present in `docker-build.yml`, so the local hook and CI now agree instead of the local hook being strictly stricter in a way that blocked all test-bearing branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)