### PR TITLE
fix(gitignore): anchor management/ — it was blackholing new source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,8 +99,11 @@ coverage
 htmlcov/
 coverage.xml
 
-# Stray top-level management/ dir (distinct from services/management/)
-management/
+# Stray top-level management/ dir (distinct from services/management/).
+# MUST stay anchored with a leading slash: a bare `management/` matches at every
+# depth, which silently blackholed every NEW file under services/management/,
+# tests/unit/management/ and services/management/alembic/versions/.
+/management/
 
 # nyc test coverage
 .nyc_output


### PR DESCRIPTION
Regression introduced by #119. Self-inflicted, caught by a feature branch.

## What happened

#119 added a bare `management/` entry to ignore a stray top-level directory containing a single `.pyc`. Gitignore patterns **without a leading slash match at every depth**, so it also matched:

- `services/management/`
- `tests/unit/management/`
- `services/management/alembic/versions/`

Every **new** file added under any of those was silently ignored. Already-tracked files were unaffected — which is precisely what made it invisible: the test suite stayed green, and `git add -A` reported nothing missing.

## How it surfaced

A feature branch found 5 of its own new files absent from `git status`: a migration, an API module, and three test modules. Nothing failed; the files simply never entered git.

## Fix

Anchor to `/management/`, which is what the entry's own comment already described ("distinct from `services/management/`"). Verified with `git check-ignore -v`:

| Path | Before | After |
|---|---|---|
| `services/management/app/NEW.py` | ignored | **tracked** |
| `tests/unit/management/test_new.py` | ignored | **tracked** |
| `services/management/alembic/versions/010_x.py` | ignored | **tracked** |
| `management/stray.pyc` | ignored | ignored ✓ |

Audited all five in-flight worktrees for files lost this way: zero remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)