### PR TITLE
feat(security): Tetragon exec allowlists, admission policies, PSA hardening (§12.2)

### DIFF
--- a/k8s/helm/waddleai/templates/admission-image-digest.yaml
+++ b/k8s/helm/waddleai/templates/admission-image-digest.yaml
@@ -1,0 +1,101 @@
+{{/*
+ValidatingAdmissionPolicy — digest-pinned images on WaddleAI workloads
+(spec §12.2). Off by default in this chart's values (house dependency-
+pinning rule: PenguinTech images may use mutable tags in alpha/beta, SHA256
+digest is mandatory in prod only) — wire a future prod values file with
+admissionPolicies.validatingAdmissionPolicy.enforceDigestPinnedImages: true.
+
+Guarded by BOTH the values toggle AND a live capability check, mirroring
+cilium-network-policy.yaml's pattern, so clusters without the VAP
+feature-gate render every other template cleanly and simply skip this
+object.
+*/}}
+{{- if and .Values.admissionPolicies.enabled .Values.admissionPolicies.validatingAdmissionPolicy.enabled .Values.admissionPolicies.validatingAdmissionPolicy.enforceDigestPinnedImages (or .Values.admissionPolicies.forceRender (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy")) -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ include "waddleai.fullname" . }}-image-digest
+  labels:
+    {{- include "waddleai.labels" . | nindent 4 }}
+spec:
+  failurePolicy: {{ .Values.admissionPolicies.failurePolicy }}
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+  validations:
+    - expression: "object.spec.containers.all(c, c.image.contains('@sha256:'))"
+      message: "WaddleAI container images must be pinned by SHA256 digest (image@sha256:<digest>)"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ include "waddleai.fullname" . }}-image-digest-binding
+  labels:
+    {{- include "waddleai.labels" . | nindent 4 }}
+spec:
+  policyName: {{ include "waddleai.fullname" . }}-image-digest
+  validationActions: {{ .Values.admissionPolicies.validationActions | toJson }}
+  matchResources:
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: [{{ .Values.namespace | quote }}]
+    objectSelector:
+      matchLabels:
+        {{- include "waddleai.selectorLabels" . | nindent 8 }}
+{{- end }}
+{{/*
+Optional Kyverno ClusterPolicy alternative — additive only, per house rule
+never the default posture (devops-kubernetes.md Cluster Security Baseline).
+Renders only when explicitly opted in (admissionPolicies.kyverno.enabled)
+AND Kyverno's own CRDs are present on the cluster (or forceRender for
+offline golden renders).
+*/}}
+{{- if and .Values.admissionPolicies.enabled .Values.admissionPolicies.kyverno.enabled (or .Values.admissionPolicies.forceRender (.Capabilities.APIVersions.Has "kyverno.io/v1/ClusterPolicy")) }}
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ include "waddleai.fullname" . }}-digest-nonroot
+  labels:
+    {{- include "waddleai.labels" . | nindent 4 }}
+spec:
+  validationFailureAction: {{ if has "Deny" .Values.admissionPolicies.validationActions }}Enforce{{ else }}Audit{{ end }}
+  background: false
+  rules:
+    - name: require-digest-pinned-images
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+              namespaces: [{{ .Values.namespace | quote }}]
+              selector:
+                matchLabels:
+                  {{- include "waddleai.selectorLabels" . | nindent 18 }}
+      validate:
+        message: "WaddleAI container images must be pinned by SHA256 digest"
+        pattern:
+          spec:
+            containers:
+              - image: "*@sha256:*"
+    - name: require-non-root
+      match:
+        any:
+          - resources:
+              kinds: ["Pod"]
+              namespaces: [{{ .Values.namespace | quote }}]
+              selector:
+                matchLabels:
+                  {{- include "waddleai.selectorLabels" . | nindent 18 }}
+      validate:
+        message: "WaddleAI containers must run as non-root"
+        pattern:
+          spec:
+            containers:
+              - securityContext:
+                  runAsNonRoot: true
+{{- end }}

--- a/k8s/helm/waddleai/templates/admission-securitycontext.yaml
+++ b/k8s/helm/waddleai/templates/admission-securitycontext.yaml
@@ -1,0 +1,70 @@
+{{/*
+ValidatingAdmissionPolicy — securityContext hardening on WaddleAI workloads
+(spec §12.2): non-root, read-only root filesystem, dropped capabilities, no
+privilege escalation, no hostPath volumes, no hostNetwork. Each CEL check is
+individually toggled (see values.yaml comment on why several default off
+today) so classes not yet compliant chart-wide can stay disabled without
+turning off the others.
+
+Guarded by BOTH the values toggle AND a live capability check
+(.Capabilities.APIVersions.Has, or admissionPolicies.forceRender for offline
+golden renders), mirroring cilium-network-policy.yaml's pattern, so clusters
+without the VAP feature-gate (<1.30, or the gate disabled) render every
+other template cleanly and simply skip this object.
+*/}}
+{{- if and .Values.admissionPolicies.enabled .Values.admissionPolicies.validatingAdmissionPolicy.enabled (or .Values.admissionPolicies.forceRender (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy")) -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ include "waddleai.fullname" . }}-securitycontext
+  labels:
+    {{- include "waddleai.labels" . | nindent 4 }}
+spec:
+  failurePolicy: {{ .Values.admissionPolicies.failurePolicy }}
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["pods"]
+  validations:
+    {{- if .Values.admissionPolicies.validatingAdmissionPolicy.enforceNonRoot }}
+    - expression: "(has(object.spec.securityContext) && object.spec.securityContext.runAsNonRoot == true) || object.spec.containers.all(c, has(c.securityContext) && c.securityContext.runAsNonRoot == true)"
+      message: "WaddleAI workloads must run as non-root (runAsNonRoot: true, pod- or container-level)"
+    {{- end }}
+    {{- if .Values.admissionPolicies.validatingAdmissionPolicy.enforceReadOnlyRootFs }}
+    - expression: "object.spec.containers.all(c, has(c.securityContext) && c.securityContext.readOnlyRootFilesystem == true)"
+      message: "WaddleAI containers must set readOnlyRootFilesystem: true"
+    {{- end }}
+    {{- if .Values.admissionPolicies.validatingAdmissionPolicy.enforceDropAllCaps }}
+    - expression: "object.spec.containers.all(c, has(c.securityContext) && has(c.securityContext.capabilities) && has(c.securityContext.capabilities.drop) && c.securityContext.capabilities.drop.exists(d, d == 'ALL'))"
+      message: "WaddleAI containers must drop ALL capabilities"
+    {{- end }}
+    {{- if .Values.admissionPolicies.validatingAdmissionPolicy.enforceNoPrivilegeEscalation }}
+    - expression: "object.spec.containers.all(c, has(c.securityContext) && c.securityContext.allowPrivilegeEscalation == false)"
+      message: "WaddleAI containers must set allowPrivilegeEscalation: false"
+    {{- end }}
+    - expression: "!has(object.spec.volumes) || object.spec.volumes.all(v, !has(v.hostPath))"
+      message: "WaddleAI workloads must not mount hostPath volumes"
+    - expression: "!has(object.spec.hostNetwork) || object.spec.hostNetwork == false"
+      message: "WaddleAI workloads must not use hostNetwork"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ include "waddleai.fullname" . }}-securitycontext-binding
+  labels:
+    {{- include "waddleai.labels" . | nindent 4 }}
+spec:
+  policyName: {{ include "waddleai.fullname" . }}-securitycontext
+  validationActions: {{ .Values.admissionPolicies.validationActions | toJson }}
+  matchResources:
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values: [{{ .Values.namespace | quote }}]
+    objectSelector:
+      matchLabels:
+        {{- include "waddleai.selectorLabels" . | nindent 8 }}
+{{- end }}

--- a/k8s/helm/waddleai/templates/management-deployment.yaml
+++ b/k8s/helm/waddleai/templates/management-deployment.yaml
@@ -30,9 +30,29 @@ spec:
         - name: wait-for-postgres
           image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
           command: ['sh', '-c', 'until nc -z {{ include "waddleai.fullname" . }}-postgres 5432; do echo waiting for postgres; sleep 2; done;']
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
         - name: wait-for-valkey
           image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
           command: ['sh', '-c', 'until nc -z {{ include "waddleai.fullname" . }}-valkey 6379; do echo waiting for valkey; sleep 2; done;']
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
       containers:
         - name: management
           securityContext:

--- a/k8s/helm/waddleai/templates/namespace.yaml
+++ b/k8s/helm/waddleai/templates/namespace.yaml
@@ -5,3 +5,10 @@ metadata:
   labels:
     {{- include "waddleai.labels" . | nindent 4 }}
     name: {{ .Values.namespace }}
+    {{- if .Values.podSecurityAdmission.enabled }}
+    # Pod Security Admission baseline (spec §12.2). See values.yaml /
+    # values-beta.yaml for why `enforce` differs from `restricted` today.
+    pod-security.kubernetes.io/enforce: {{ .Values.podSecurityAdmission.enforce }}
+    pod-security.kubernetes.io/audit: {{ .Values.podSecurityAdmission.audit }}
+    pod-security.kubernetes.io/warn: {{ .Values.podSecurityAdmission.warn }}
+    {{- end }}

--- a/k8s/helm/waddleai/templates/postgres-deployment.yaml
+++ b/k8s/helm/waddleai/templates/postgres-deployment.yaml
@@ -30,6 +30,23 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: postgres
+          # readOnlyRootFilesystem: true — PGDATA is already volume-backed
+          # (postgres-data below); the official postgres image also needs
+          # write access to create its unix-socket file at
+          # unix_socket_directories (Debian default /var/run/postgresql,
+          # baked into the image but not writable once RORFS is on) — backed
+          # by the postgres-run emptyDir below. /tmp is mounted for parity
+          # with the rest of this chart's containers.
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
           image: {{ include "waddleai.postgres.image" . }}
           imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
           ports:
@@ -75,6 +92,10 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data
+            - name: postgres-run
+              mountPath: /var/run/postgresql
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: postgres-data
           {{- if .Values.postgres.persistence.enabled }}
@@ -83,6 +104,10 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        - name: postgres-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/k8s/helm/waddleai/templates/proxy-deployment.yaml
+++ b/k8s/helm/waddleai/templates/proxy-deployment.yaml
@@ -30,9 +30,29 @@ spec:
         - name: wait-for-postgres
           image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
           command: ['sh', '-c', 'until nc -z {{ include "waddleai.fullname" . }}-postgres 5432; do echo waiting for postgres; sleep 2; done;']
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
         - name: wait-for-valkey
           image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
           command: ['sh', '-c', 'until nc -z {{ include "waddleai.fullname" . }}-valkey 6379; do echo waiting for valkey; sleep 2; done;']
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
       containers:
         - name: proxy
           securityContext:
@@ -40,6 +60,8 @@ spec:
             runAsUser: 1000
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
             capabilities:
               drop:
                 - ALL

--- a/k8s/helm/waddleai/templates/tetragon-egress-policy.yaml
+++ b/k8s/helm/waddleai/templates/tetragon-egress-policy.yaml
@@ -1,0 +1,52 @@
+{{/*
+Tetragon egress-observe: flags AIProxy outbound connections and unexpected
+file-write activity (spec §12.2). Always logs (Post) rather than kills —
+FQDN allow-listing to provider endpoints is the cilium-reconciler CNP's job
+(§12.1, cilium-network-policy.yaml's waddleai-allow-aiproxy-egress rule);
+this policy observes/flags only and intentionally does not duplicate that
+allow-list. CIDR-scoped hard blocking is a documented follow-up, not
+silently dropped — see tetragon.egress in values.yaml.
+
+Guarded by BOTH the values toggle AND a live capability check, mirroring
+cilium-network-policy.yaml's pattern, so non-Tetragon clusters render every
+other template cleanly and simply skip this object (§12.3).
+*/}}
+{{- if and .Values.tetragon.enabled .Values.tetragon.egress.enabled (or .Values.tetragon.forceRender (.Capabilities.APIVersions.Has "cilium.io/v1alpha1/TracingPolicyNamespaced")) -}}
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicyNamespaced
+metadata:
+  name: {{ include "waddleai.fullname" . }}-egress-observe
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "waddleai.labels" . | nindent 4 }}
+    app.kubernetes.io/component: proxy
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "waddleai.selectorLabels" . | nindent 6 }}
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values: ["proxy"]
+  kprobes:
+    - call: "tcp_connect"
+      syscall: false
+      args:
+        - index: 0
+          type: "sock"
+      selectors:
+        - matchActions:
+            - action: Post
+    {{- if .Values.tetragon.egress.flagUnexpectedFileWrites }}
+    - call: "security_file_permission"
+      syscall: false
+      args:
+        - index: 0
+          type: "file"
+        - index: 1
+          type: "int"
+      selectors:
+        - matchActions:
+            - action: Post
+    {{- end }}
+{{- end }}

--- a/k8s/helm/waddleai/templates/tetragon-exec-policy.yaml
+++ b/k8s/helm/waddleai/templates/tetragon-exec-policy.yaml
@@ -1,0 +1,58 @@
+{{/*
+Tetragon exec-guard: an ENFORCED allowlist of each targeted component's own
+runtime binaries (spec §12.2; house security mandate — allowlist, not
+observe-only). One TracingPolicyNamespaced per component so the allowlist
+stays scoped to that pod's actual process inventory (a Python service's
+allowed binaries are not ollama's) rather than one policy loose enough to
+cover everyone and therefore covering no one.
+
+Guarded by BOTH the values toggle (tetragon.enabled + tetragon.exec.enabled)
+AND a live capability check (.Capabilities.APIVersions.Has, or
+tetragon.forceRender for offline golden renders), mirroring
+cilium-network-policy.yaml's pattern, so non-Tetragon clusters render every
+other template in the chart cleanly and simply skip these objects (§12.3)
+rather than failing `helm install`.
+*/}}
+{{- if and .Values.tetragon.enabled .Values.tetragon.exec.enabled (or .Values.tetragon.forceRender (.Capabilities.APIVersions.Has "cilium.io/v1alpha1/TracingPolicyNamespaced")) -}}
+{{- range $comp, $cfg := .Values.tetragon.exec.components }}
+{{- if $cfg.enabled }}
+---
+apiVersion: cilium.io/v1alpha1
+kind: TracingPolicyNamespaced
+metadata:
+  name: {{ include "waddleai.fullname" $ }}-exec-allowlist-{{ $comp }}
+  namespace: {{ $.Values.namespace }}
+  labels:
+    {{- include "waddleai.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $comp }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "waddleai.selectorLabels" $ | nindent 6 }}
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values: [{{ $comp | quote }}]
+  kprobes:
+    - call: "sys_execve"
+      syscall: true
+      args:
+        - index: 0
+          type: "string"
+      selectors:
+        - matchArgs:
+            - index: 0
+              operator: "NotIn"
+              values:
+                {{- range $cfg.allowedExecs }}
+                - {{ . | quote }}
+                {{- end }}
+          matchActions:
+            {{- if eq $cfg.mode "enforce" }}
+            - action: Sigkill
+            {{- else }}
+            - action: Post
+            {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/k8s/helm/waddleai/templates/valkey-deployment.yaml
+++ b/k8s/helm/waddleai/templates/valkey-deployment.yaml
@@ -30,6 +30,21 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: valkey
+          # readOnlyRootFilesystem: true — valkey's default working
+          # directory (dir) is /data, already volume-backed below
+          # (valkey-data); /tmp is mounted for parity with the rest of this
+          # chart's containers even though the default config here doesn't
+          # require it.
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
           image: {{ include "waddleai.valkey.image" . }}
           imagePullPolicy: {{ .Values.valkey.image.pullPolicy }}
           {{- if .Values.valkey.args }}
@@ -65,6 +80,8 @@ spec:
           volumeMounts:
             - name: valkey-data
               mountPath: /data
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: valkey-data
           {{- if .Values.valkey.persistence.enabled }}
@@ -73,6 +90,8 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        - name: tmp
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/k8s/helm/waddleai/templates/webui-deployment.yaml
+++ b/k8s/helm/waddleai/templates/webui-deployment.yaml
@@ -33,6 +33,8 @@ spec:
             runAsUser: 1000
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
+            seccompProfile:
+              type: RuntimeDefault
             capabilities:
               drop:
                 - ALL

--- a/k8s/helm/waddleai/values-alpha.yaml
+++ b/k8s/helm/waddleai/values-alpha.yaml
@@ -132,3 +132,30 @@ cilium:
     enabled: true
   topology:
     gatewayNamespace: gateway
+
+# Tetragon + admission policies - Alpha
+# Dev-friendly: AIProxy/Management exec allowlists relaxed to observe (no
+# enforced kills while iterating locally) and admission failurePolicy
+# relaxed to Ignore. Local MicroK8s frequently lacks the Tetragon/VAP CRDs
+# entirely — the capability guard in each template already no-ops cleanly
+# there; these overrides just make the alpha experience non-disruptive on
+# clusters that DO have the CRDs.
+tetragon:
+  exec:
+    components:
+      proxy:
+        mode: observe
+      management:
+        mode: observe
+
+admissionPolicies:
+  failurePolicy: Ignore
+
+# Pod Security Admission - Alpha
+# Alpha never enables ollama (no hostPath volume) or the GPU-operator
+# subcharts (no node-feature-discovery hostPaths), and this chart's own
+# containers are now seccompProfile/drop-ALL-capabilities compliant (see
+# values.yaml comment) — `restricted` is fully reachable here. `audit`/
+# `warn` were already `restricted`; this raises `enforce` to match.
+podSecurityAdmission:
+  enforce: restricted

--- a/k8s/helm/waddleai/values-beta.yaml
+++ b/k8s/helm/waddleai/values-beta.yaml
@@ -263,3 +263,21 @@ cilium:
   topology:
     gatewayName: shared
     gatewayNamespace: gateway
+
+# Tetragon + admission policies - Beta (spec §12.2)
+# AIProxy/Management exec allowlists already default to `enforce` in
+# values.yaml — nothing to override here. `admissionPolicies.validationActions`
+# also stays inherited at `Warn` rather than `Deny`: implementation-time
+# audit found postgres/valkey ship with no container-level `securityContext`
+# at all, so `Deny` would reject those pods on every beta install (tracked
+# follow-up, not silently dropped). Pod Security Admission `enforce` is
+# relaxed below for the same class of reason plus dal2-beta's ollama
+# DaemonSet using a hostPath volume for model storage (see
+# ollama.persistence.hostPath above) — hostPath volumes are forbidden
+# starting at the `baseline` PSA level, so the chart default would reject
+# every ollama pod on this cluster. `audit`/`warn` stay `restricted` so the
+# gap remains visible. Tracked follow-up: migrate beta ollama to the
+# PVC-backed path this chart already supports (ollama.persistence.enabled)
+# so `baseline` can be restored here.
+podSecurityAdmission:
+  enforce: privileged

--- a/k8s/helm/waddleai/values.yaml
+++ b/k8s/helm/waddleai/values.yaml
@@ -376,6 +376,8 @@ securityContext:
   readOnlyRootFilesystem: false
   runAsNonRoot: true
   runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 # Node selector
 nodeSelector: {}
@@ -659,3 +661,122 @@ intel-gpu-plugin:
   namespace: kube-system
   nodeSelector: {}
   sharedDevNum: 1
+
+# ---------------------------------------------------------------------------
+# Tetragon runtime-security TracingPolicies + Kubernetes admission policies
+# (platform spec §12.2). ON by default, each protection class independently
+# switchable via its own values toggle. Every CRD-emitting template below is
+# guarded by BOTH its values toggle AND a live capability check
+# (`.Capabilities.APIVersions.Has`), mirroring the cilium-reconciler branch's
+# pattern above (cilium-network-policy.yaml), so a cluster without
+# Tetragon/the VAP feature-gate still renders every other template cleanly
+# and simply skips these objects (§12.3) instead of failing `helm install`.
+# `forceRender: true` bypasses the live capability check — only meant for
+# offline `helm template` golden-file rendering (CI), never set in a real
+# values-*.yaml that gets `helm install`ed against a live cluster.
+tetragon:
+  enabled: true
+  forceRender: false
+  exec:
+    # ENFORCED allowlist of each targeted component's own runtime binaries —
+    # not observe-only (house security mandate: an allowlist that only logs
+    # is the failure mode this policy exists to prevent). One
+    # TracingPolicyNamespaced per component so the allowlist stays scoped to
+    # that pod's actual process inventory (a Python service's allowed
+    # binaries are not ollama's) rather than one policy loose enough to
+    # cover everyone and therefore covering no one. `mode: enforce` kills
+    # any exec outside `allowedExecs`; `mode: observe` logs only.
+    enabled: true
+    components:
+      # AIProxy — this repo's own image (proxy/Dockerfile). System-wide pip
+      # install puts console-script binaries under /usr/local/bin; full
+      # binary inventory known. Enforced by default — spec §12.2 names
+      # AIProxy explicitly as the primary exec-guard target.
+      proxy:
+        enabled: true
+        mode: enforce
+        allowedExecs:
+          - /usr/local/bin/python3
+          - /usr/local/bin/hypercorn
+      # Management — this repo's own image (services/management/Dockerfile),
+      # installed into a venv at /opt/venv.
+      management:
+        enabled: true
+        mode: enforce
+        allowedExecs:
+          - /opt/venv/bin/python3
+          - /opt/venv/bin/hypercorn
+      # Ollama — third-party vendor image (ollama/ollama). Binary path is
+      # believed stable (/bin/ollama) but not verified against a live
+      # cluster by this branch, and the model-pull initContainer execs
+      # /bin/sh (the pod selector matches the whole pod, not per-container).
+      # Default observe until confirmed in kind/beta; flip to enforce once
+      # validated.
+      ollama:
+        enabled: true
+        mode: observe
+        allowedExecs:
+          - /bin/ollama
+          - /bin/sh
+      # llama.cpp server — third-party vendor image; same caveat as ollama
+      # (curl-based model-download initContainer shares the pod).
+      llamacpp:
+        enabled: true
+        mode: observe
+        allowedExecs:
+          - /llama-server
+          - /bin/sh
+          - /usr/bin/curl
+  egress:
+    # Observe/flag AIProxy egress + unexpected file-write activity (spec
+    # §12.2). FQDN allow-listing to provider endpoints is the
+    # cilium-reconciler CNP's job (§12.1) — this policy observes and logs
+    # only; it does not duplicate that allow-list, and does not yet
+    # implement CIDR-scoped hard blocking (tracked follow-up, not silently
+    # dropped).
+    enabled: true
+    flagUnexpectedFileWrites: true
+
+# Kubernetes admission policies enforcing pod-security baseline on WaddleAI
+# workloads (spec §12.2): ValidatingAdmissionPolicy core, Kyverno optional
+# (additive-only per house rule — never the default posture). Each CEL check
+# individually toggled. `validationActions` defaults to `Warn`
+# (non-blocking) chart-wide: an implementation-time audit found
+# postgres/valkey containers ship with no container-level `securityContext`
+# at all today (only pod-level), and several containers still set
+# `readOnlyRootFilesystem: false` — defaulting straight to `Deny` would
+# reject those pods on every `helm install`. `Warn` surfaces every violation
+# (visible on `kubectl apply`/`helm install` output) with zero blast radius;
+# flip to `Deny` once the flagged workloads are hardened (tracked follow-up,
+# not silently dropped).
+admissionPolicies:
+  enabled: true
+  forceRender: false
+  failurePolicy: Fail
+  validationActions: [Warn]
+  validatingAdmissionPolicy:
+    enabled: true
+    enforceNonRoot: true              # already compliant: podSecurityContext.runAsNonRoot=true chart-wide
+    enforceReadOnlyRootFs: false      # webui/management/postgres/valkey/ollama set false today; enable once hardened
+    enforceDropAllCaps: true          # flags postgres/valkey (no container securityContext yet) under Warn
+    enforceNoPrivilegeEscalation: true
+    enforceDigestPinnedImages: false  # alpha/beta intentionally use mutable tags (house pinning rule); enable in a prod values file
+  kyverno:
+    enabled: false   # optional alternative engine; only renders if opted in AND its CRDs are present
+
+# Pod Security Admission namespace labels (spec §12.2 "restricted" baseline).
+# `audit`/`warn` default to `restricted` everywhere (non-blocking, surfaces
+# every violation via the API audit log / kubectl warnings). `enforce`
+# defaults to `baseline` here (this chart's own containers — proxy,
+# management, webui, postgres, valkey, plus the wait-for-postgres/valkey
+# initContainers — are now `seccompProfile: RuntimeDefault` +
+# drop-ALL-capabilities compliant, but `restricted` is only actually
+# reachable in environments free of third-party subchart / hostPath gaps).
+# values-alpha.yaml overrides to `restricted` (no ollama hostPath, no
+# gpu-operator/node-feature-discovery there). See values-beta.yaml for why
+# beta stays lower.
+podSecurityAdmission:
+  enabled: true
+  enforce: baseline
+  audit: restricted
+  warn: restricted


### PR DESCRIPTION
Implements §12.2. Capability-guarded the same way the Cilium reconciler (#122) is — a cluster without the CRDs renders **zero** objects and the rest of the chart is unaffected.

## Enforced, not observe-only

`proxy` and `management` get exec allowlists using `operator: NotIn` + `matchActions: [{action: Sigkill}]`.

`ollama` and `llamacpp` are deliberately **observe** (`action: Post`): they run third-party images whose binary paths aren't verified, and share a pod with an initContainer that execs `/bin/sh` and `curl` during model pulls — a kill action would break legitimate model-pull chains. Documented in-file rather than left as a silent inconsistency.

Beta with CRDs present renders **2 × `Sigkill`, 4 × `Post`**.

## Pre-existing hole this surfaced and closes

Auditing the rendered output turned up that **`postgres` and `valkey` were the only containers in the chart shipping with no `securityContext` at all**, and `seccompProfile` appeared **zero times** in either render — meaning the mandatory PSA `restricted` baseline was unreachable and had been for some time.

| Container | Change |
|---|---|
| `postgres`, `valkey` | `runAsNonRoot`, `allowPrivilegeEscalation: false`, drop `ALL`, `seccompProfile: RuntimeDefault`, `readOnlyRootFilesystem: true` |
| `proxy`, `management`, `webui` | added `seccompProfile: RuntimeDefault` (had the rest) |
| `wait-for-postgres` / `wait-for-valkey` initContainers | full block incl. RORFS |

`postgres` needed a `postgres-run` emptyDir for its unix socket, which `readOnlyRootFilesystem` otherwise breaks.

## Alpha now enforces PSA `restricted`

With our own containers compliant, `values-alpha.yaml` moves to `enforce: restricted`. Verified: 0 containers missing `securityContext`, 0 hostPath volumes.

**Beta stays `privileged`** — its remaining gaps are 100% third-party and deliberately untouched: `gpu-operator` ships a container with no `securityContext`, and `node-feature-discovery` (7) plus the `ollama` model cache (1) mount 8 hostPath volumes between them.

`admissionPolicies.validationActions` stays `Warn` everywhere. `Deny` is now plausible for alpha, but not flipped here — that's a deliberate call to make separately.

## Verification

| Check | alpha | beta |
|---|---|---|
| `helm lint` | 0 failed | 0 failed |
| `helm template` | clean | clean |
| CRDs **absent** → Tetragon/VAP objects | **0** | **0** |
| containers missing `securityContext` | **none** | `gpu-operator` only (third-party) |
| hostPath volumes | none | third-party only |
| PSA enforce | `restricted` | `privileged` |

`pytest tests/unit/` → 1200 passed, 4 skipped (unchanged — no Python touched).

> Note: `helm template` fails in a fresh worktree until `helm dependency build` runs (missing `gpu-operator`). It exits 0 while printing an error, so an audit piped from it will read as clean when it has actually parsed nothing. Worth knowing before trusting any chart audit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)