### PR TITLE
fix(security): missing spaCy model crashed the process instead of degrading

### DIFF
--- a/shared/security/ner_filter.py
+++ b/shared/security/ner_filter.py
@@ -126,7 +126,17 @@ class NERFilter:
             self._available = True
             self._mode = "presidio"
             logger.info(f"NER filter initialized: Presidio + spaCy ({spacy_model})")
-        except Exception as e:
+        except (Exception, SystemExit) as e:
+            # SystemExit is deliberate and load-bearing, not defensive padding.
+            # spaCy loads models through wasabi, which calls sys.exit() rather
+            # than raising when a model is not installed. SystemExit derives
+            # from BaseException, so a bare `except Exception` does NOT catch
+            # it: the interpreter dies instead of falling through to the
+            # documented "NER tier will be skipped" degradation below. spaCy
+            # models are not pip-installable alongside the spacy package, so a
+            # missing en_core_web_lg is the normal state of any environment
+            # that has not explicitly run `python -m spacy download` -- which
+            # made this an unhandled startup crash, not an edge case.
             logger.warning(
                 f"Presidio NER init failed ({e}). "
                 "Trying transformers fallback."

--- a/tests/unit/security/test_ner_filter_missing_model.py
+++ b/tests/unit/security/test_ner_filter_missing_model.py
@@ -1,0 +1,103 @@
+"""Regression tests for NER init when the spaCy model is absent.
+
+spaCy loads models through wasabi, which calls ``sys.exit()`` rather than
+raising when a model is missing. ``SystemExit`` derives from
+``BaseException``, so a bare ``except Exception`` does not catch it and the
+interpreter dies during ``NERFilter()`` construction instead of degrading to
+the documented "NER tier will be skipped" behaviour.
+
+This is the normal state of any environment that has not explicitly run
+``python -m spacy download en_core_web_lg`` -- spaCy models are not
+pip-installable alongside the ``spacy`` package -- so it was an unhandled
+startup crash rather than an edge case. It reached CI as
+``SystemExit: 1`` aborting the whole unit-test run.
+"""
+
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def _presidio_raising(monkeypatch, request):
+    """Install a fake presidio whose engine factory raises ``request.param``.
+
+    Yields the freshly-imported ``ner_filter`` module with
+    ``_PRESIDIO_AVAILABLE`` forced on, so ``_init_presidio`` is reached.
+    """
+    exc = request.param
+
+    analyzer_mod = types.ModuleType("presidio_analyzer")
+
+    class _AnalyzerEngine:
+        def __init__(self, **_kwargs):
+            pass
+
+    analyzer_mod.AnalyzerEngine = _AnalyzerEngine
+
+    nlp_mod = types.ModuleType("presidio_analyzer.nlp_engine")
+
+    class _NlpEngineProvider:
+        def __init__(self, **_kwargs):
+            pass
+
+        def create_engine(self):
+            raise exc
+
+    nlp_mod.NlpEngineProvider = _NlpEngineProvider
+
+    monkeypatch.setitem(sys.modules, "presidio_analyzer", analyzer_mod)
+    monkeypatch.setitem(sys.modules, "presidio_analyzer.nlp_engine", nlp_mod)
+
+    from shared.security import ner_filter
+
+    monkeypatch.setattr(ner_filter, "_PRESIDIO_AVAILABLE", True)
+    monkeypatch.setattr(ner_filter, "_TRANSFORMERS_NER_AVAILABLE", False)
+    return ner_filter
+
+
+@pytest.mark.parametrize(
+    "_presidio_raising",
+    [SystemExit("[E050] Can't find model 'en_core_web_lg'")],
+    indirect=True,
+)
+def test_missing_spacy_model_degrades_instead_of_exiting(_presidio_raising):
+    """A missing spaCy model must not terminate the process.
+
+    Regression: wasabi's ``sys.exit`` escaped ``except Exception`` and killed
+    both the proxy at startup and the CI unit-test run.
+    """
+    ner = _presidio_raising.NERFilter()
+
+    assert ner._available is False
+    assert ner._mode == "none"
+
+
+@pytest.mark.parametrize(
+    "_presidio_raising",
+    [RuntimeError("presidio blew up for some other reason")],
+    indirect=True,
+)
+def test_ordinary_init_failure_still_degrades(_presidio_raising):
+    """The pre-existing ``Exception`` path must keep working unchanged."""
+    ner = _presidio_raising.NERFilter()
+
+    assert ner._available is False
+    assert ner._mode == "none"
+
+
+@pytest.mark.parametrize(
+    "_presidio_raising",
+    [KeyboardInterrupt()],
+    indirect=True,
+)
+def test_keyboard_interrupt_is_not_swallowed(_presidio_raising):
+    """Widening to ``SystemExit`` must not also swallow ``KeyboardInterrupt``.
+
+    Catching ``BaseException`` wholesale would make Ctrl-C during startup
+    silently continue with NER disabled, which is why the handler names
+    ``SystemExit`` explicitly rather than broadening.
+    """
+    with pytest.raises(KeyboardInterrupt):
+        _presidio_raising.NERFilter()


### PR DESCRIPTION
Blocks the entire merge chain — surfaced as `test (3.13)` failing on #126, a four-file annotation diff that couldn't plausibly break anything.

## Root cause

`NERFilter._init_presidio` catches `Exception`. But spaCy loads models through **wasabi**, which calls `sys.exit()` rather than raising when a model is missing. `SystemExit` derives from `BaseException`, so `except Exception` **never catches it** — the interpreter dies mid-construction, skipping the documented fallback three lines below:

```
"NER filter unavailable: install 'presidio-analyzer' + a spaCy model
 (python -m spacy download en_core_web_lg) ... NER tier will be skipped."
```

## This is the normal state, not an edge case

`spacy==3.8.15` is a declared dependency, so CI installs the library. But **nothing in the repo or CI ever runs `python -m spacy download`** — spaCy models aren't pip-installable alongside the package. So any environment that hasn't hand-installed a model hits this path.

- **In CI**: `SystemExit: 1` aborts the whole unit-test run.
- **In production**: the proxy fails to start, rather than running with NER disabled — the opposite of what the surrounding code promises.

It passed locally only because spaCy isn't installed here *at all*, so the code took a different branch entirely. Local green, CI red, **and CI was right.**

## Fix

`except (Exception, SystemExit)`. Deliberately **not** broadened to `BaseException` — `KeyboardInterrupt` must still propagate, since Ctrl-C during startup silently continuing with NER disabled would be its own bug.

Verified by simulating a model-missing load:

```
Presidio NER init failed ([E050] Can't find model 'en_core_web_lg'). Trying transformers fallback.
survived SystemExit -> available=False mode='none'
```

## Regression tests

Three cases, because widening an exception handler is exactly where over-correction hides:

| Test | Asserts |
|---|---|
| `test_missing_spacy_model_degrades_instead_of_exiting` | `SystemExit` → degrades, no process exit |
| `test_ordinary_init_failure_still_degrades` | pre-existing `Exception` path unchanged |
| `test_keyboard_interrupt_is_not_swallowed` | `KeyboardInterrupt` still propagates |

## Verification

| Check | Result |
|---|---|
| `pytest tests/unit/` | **1203 passed, 4 skipped** (baseline 1200/4, +3) |
| ruff, `ner_filter.py` | HEAD 4 → now **4** (zero delta; new test file clean) |
| bandit | 0 at every severity |

> Follow-up worth considering separately: CI installs `spacy` but no model, so the NER tier is silently untested there. Either download the model in the workflow or drop the dependency from the test environment — right now it's the worst of both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)